### PR TITLE
Revert use of Simplified GIL State API

### DIFF
--- a/_pylibmcmodule.c
+++ b/_pylibmcmodule.c
@@ -584,7 +584,7 @@ static PyObject *_PylibMC_RunSetCommandMulti(PylibMC_Client* self,
 
     bool allsuccess = _PylibMC_RunSetCommand(self, f, fname,
                                              serialized, nkeys, 
-                                             time);
+                                             min_compress);
 
     if (PyErr_Occurred() != NULL) {
         goto cleanup;


### PR DESCRIPTION
The Simplified GIL State API is not compatible nor supported with the use of sub-interpreters such as those used by mod_wsgi
