### PR TITLE
added custom_flag option which sets a custom memcache flag

### DIFF
--- a/_pylibmcmodule.c
+++ b/_pylibmcmodule.c
@@ -475,17 +475,17 @@ static PyObject *_PylibMC_RunSetCommandSingle(PylibMC_Client *self,
         _PylibMC_SetCommand f, char *fname, PyObject *args,
         PyObject *kwds) {
     /* function called by the set/add/etc commands */
-    static char *kws[] = { "key", "val", "time", "custom_flag", "min_compress_len", NULL };
+    static char *kws[] = { "key", "val", "time", "min_compress_len", "custom_flag", NULL };
     PyObject *key;
     PyObject *value;
     unsigned int time = 0; /* this will be turned into a time_t */
-    unsigned int custom_flag = 0;
     unsigned int min_compress = 0;
+    unsigned int custom_flag = 0;
     bool success = false;
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "SO|III", kws,
-                                     &key, &value,
-                                     &time, &custom_flag, &min_compress)) {
+                                     &key, &value, &time,
+                                     &min_compress, &custom_flag)) {
       return NULL;
     }
 
@@ -505,8 +505,8 @@ static PyObject *_PylibMC_RunSetCommandSingle(PylibMC_Client *self,
 
     success = _PylibMC_RunSetCommand(self, f, fname,
                                      &serialized, 1,
-                                     custom_flag,
-                                     min_compress);
+                                     min_compress,
+                                     custom_flag);
 
 cleanup:
     _PylibMC_FreeMset(&serialized);
@@ -532,13 +532,12 @@ static PyObject *_PylibMC_RunSetCommandMulti(PylibMC_Client* self,
     PyObject * retval = NULL;
     size_t idx = 0;
 
-    static char *kws[] = { "keys", "time", "key_prefix", "custom_flag", "min_compress_len", NULL };
+    static char *kws[] = { "keys", "time", "key_prefix", "min_compress_len", "custom_flag", NULL };
 
     if (!PyArg_ParseTupleAndKeywords(args, kwds, "O!|ISII", kws,
                                      &PyDict_Type, &keys,
                                      &time, &key_prefix,
-                                     &custom_flag,
-                                     &min_compress)) {
+                                     &min_compress, &custom_flag)) {
         return NULL;
     }
 
@@ -587,9 +586,8 @@ static PyObject *_PylibMC_RunSetCommandMulti(PylibMC_Client* self,
     }
 
     bool allsuccess = _PylibMC_RunSetCommand(self, f, fname,
-                                             serialized, nkeys, 
-                                             custom_flag,
-                                             min_compress);
+                                             serialized, nkeys,
+                                             min_compress, custom_flag);
 
     if (PyErr_Occurred() != NULL) {
         goto cleanup;
@@ -815,8 +813,7 @@ static int _PylibMC_SerializeValue(PyObject* key_obj,
 static bool _PylibMC_RunSetCommand(PylibMC_Client* self,
                                    _PylibMC_SetCommand f, char *fname,
                                    pylibmc_mset* msets, size_t nkeys,
-                                   size_t custom_flag,
-                                   size_t min_compress) {
+                                   size_t min_compress, size_t custom_flag) {
     memcached_st* mc = self->mc;
     memcached_return rc = MEMCACHED_SUCCESS;
     int pos;

--- a/_pylibmcmodule.h
+++ b/_pylibmcmodule.h
@@ -63,7 +63,7 @@ typedef ssize_t Py_ssize_t;
 /* Note: this is an addition! python-memcached doesn't handle bools. */
 #define PYLIBMC_FLAG_BOOL    (1 << 4)
 #define PYLIBMC_FLAG_TYPES   (PYLIBMC_FLAG_PICKLE | PYLIBMC_FLAG_INTEGER | \
-                              PYLIBMC_FLAG_LONG | PYLIBMC_FLAG_BOOL | PYLIBMC_FLAG_CUSTOM)
+                              PYLIBMC_FLAG_LONG | PYLIBMC_FLAG_BOOL)
 /* Modifier flags */
 #define PYLIBMC_FLAG_ZLIB    (1 << 3)
 /* }}} */
@@ -278,8 +278,7 @@ static PyObject *_PylibMC_RunSetCommandMulti(PylibMC_Client* self,
 static bool _PylibMC_RunSetCommand(PylibMC_Client* self,
                                    _PylibMC_SetCommand f, char *fname,
                                    pylibmc_mset* msets, size_t nkeys,
-                                   size_t custom_flag,
-                                   size_t min_compress);
+                                   size_t min_compress, size_t custom_flag);
 static int _PylibMC_Deflate(char* value, size_t value_len,
                             char** result, size_t *result_len);
 static bool _PylibMC_IncrDecr(PylibMC_Client*, pylibmc_incr*, size_t);


### PR DESCRIPTION
I created a new argument for setting a custom memcached flag of any int value. This is useful for storing data in different formats and detecting it in get for proper handling without effecting the existing built-in flags for pickle, zlib compress, ect..

Example:

> > > mc = pylibmc.Client(['127.0.0.1:11211])
> > > mc.set('foo', 'bar', custom_flag=5) # will set a memcached flag of 32
> > > True

$ telnet localhost 11211
get foo
VALUE foo 32 3
bar
END
