### PR TITLE
Add hostname of offending server to exceptions.

### DIFF
--- a/_pylibmcmodule.h
+++ b/_pylibmcmodule.h
@@ -259,6 +259,8 @@ static PyObject *PylibMC_Client_get_stats(PylibMC_Client *, PyObject *);
 static PyObject *PylibMC_Client_flush_all(PylibMC_Client *, PyObject *, PyObject *);
 static PyObject *PylibMC_Client_disconnect_all(PylibMC_Client *);
 static PyObject *PylibMC_Client_clone(PylibMC_Client *);
+static PyObject *PylibMC_ErrFromMemcachedWithKey(PylibMC_Client *, const char *,
+        memcached_return, const char*, int);
 static PyObject *PylibMC_ErrFromMemcached(PylibMC_Client *, const char *,
         memcached_return);
 static PyObject *_PylibMC_Unpickle(const char *, size_t);


### PR DESCRIPTION
When a failure is received on non-multi-key operations,
include the hostname of the server responsible for the
key being operated on in the exception text.
