### PR TITLE
Added default pkgdirs so the install works out of the box on FreeBSD

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,11 @@ for arg in sys.argv[1:]:
     unprocessed.append(arg)
 sys.argv[1:] = unprocessed
 
+# If no pkgdirs are given, default to /, /usr and /usr/local which should
+# work on every standard BSD/Linux install
+if not pkgdirs:
+    pkgdirs = ['/', '/usr', '/usr/local']
+
 for pkgdir in pkgdirs:
     incdirs.append(os.path.join(pkgdir, "include"))
     libdirs.append(os.path.join(pkgdir, "lib"))


### PR DESCRIPTION
Somehow the setup fails by default on FreeBSD while it should work with a normal include.

So when no `pkgdirs` are given it now defaults to `/, /usr, /usr/local` which should work pretty much everywhere.
