### PR TITLE
Fix bug in translate_server_spec.

### DIFF
--- a/pylibmc/client.py
+++ b/pylibmc/client.py
@@ -40,7 +40,7 @@ def translate_server_spec(server, port=11211):
             addr = server[4:]
         if not addr.startswith("["):
             if ":" in addr:
-                (addr, port) = server.split(":", 1)
+                (addr, port) = addr.split(":", 1)
         else:
             if not addr.endswith("]"):
                 (addr, port) = addr.rsplit(":", 1)


### PR DESCRIPTION
Fixes parsing of udp:host:port for non-IPv6 hosts which wasn't working because when `udp:` was detected, it was stripped off `addr`, but `server` was then subsequently used to split host from port, so host would be `udp` and port would be `host:port`. 
