### PR TITLE
format string s# for PyArg_ParseTuple receives a 'int' not 'Py_ssize_t'

### DIFF
--- a/_pylibmcmodule.c
+++ b/_pylibmcmodule.c
@@ -993,7 +993,7 @@ static PyObject *PylibMC_Client_cas(PylibMC_Client *self, PyObject *args,
 static PyObject *PylibMC_Client_delete(PylibMC_Client *self, PyObject *args) {
     PyObject *retval;
     char *key;
-    Py_ssize_t key_sz;
+    int key_sz;
     memcached_return rc;
 
     retval = NULL;
@@ -1026,7 +1026,7 @@ static PyObject *_PylibMC_IncrSingle(PylibMC_Client *self,
                                      _PylibMC_IncrCommand incr_func,
                                      PyObject *args) {
     char *key;
-    Py_ssize_t key_len;
+    int key_len;
     unsigned int delta = 1;
 
     if (!PyArg_ParseTuple(args, "s#|I", &key, &key_len, &delta)) {
@@ -1305,7 +1305,7 @@ static PyObject *PylibMC_Client_get_multi(
     char **keys, *prefix = NULL;
     char *err_func = NULL;
     memcached_result_st *res, *results = NULL;
-    Py_ssize_t prefix_len = 0;
+    int prefix_len;
     Py_ssize_t i;
     PyObject *key_it, *ckey;
     size_t *key_lens;


### PR DESCRIPTION
In some environment (ex. PyPy) `sizeof(Py_ssize_t)` is 8.
But `PyArg_ParseTuple` with format `s#` uses length pointer argument as int.
So, this line may be harmful.

  PyArg_ParseTuple(args, "s#:delete", &key, &key_sz)

Because `PyArg_ParseTuple` writes 4 bytes for `&key_sz`, in spite of `sizeof(key_sz)` is 8.

We should use normal int for `PyArg_ParseTuple`.

below is result.
## before patch

```
$ python -V
Python 2.7.1 (7773f8fc4223, Nov 18 2011, 18:47:11)
[PyPy 1.7.0 with GCC 4.4.3]
$ python runtests.py     
nose.plugins.pylibmc: INFO: injected path: build/lib.linux-x86_64-2.7
nose.plugins.pylibmc: INFO: loaded _pylibmc from build/lib.linux-x86_64-2.7/_pylibmc.pypy-17.so
nose.plugins.pylibmc: INFO: libmemcached version: 1.0.2
nose.plugins.pylibmc: INFO: pylibmc version: 1.2.99-dev
nose.plugins.pylibmc: INFO: support compression: True
nose.plugins.pylibmc: INFO: support sasl auth: True
E.FF.F.F...E.EEFE......
```
## after patch

```
$ python runtests.py 
nose.plugins.pylibmc: INFO: injected path: build/lib.linux-x86_64-2.7
nose.plugins.pylibmc: INFO: loaded _pylibmc from build/lib.linux-x86_64-2.7/_pylibmc.pypy-17.so
nose.plugins.pylibmc: INFO: libmemcached version: 1.0.2
nose.plugins.pylibmc: INFO: pylibmc version: 1.2.99-dev
nose.plugins.pylibmc: INFO: support compression: True
nose.plugins.pylibmc: INFO: support sasl auth: True
......F...............
```
