### PR TITLE
Custom Pickler implementations

### DIFF
--- a/pylibmc/__init__.py
+++ b/pylibmc/__init__.py
@@ -61,6 +61,57 @@ Batch operation::
     >>> mc.delete_multi(["cats", "dogs", "bacon"])
     True
 
+Custom picklers::
+
+    >>> mc.set("key", {"complex": True})
+    True
+    >>> mc.get("key")
+    {'complex': True}
+    >>> mc.set_pickler("json")
+    True
+    >>> mc.set("key", {"complex": True})
+    True
+    >>> mc.set_pickler()
+    Traceback (most recent call last):
+      ...
+    TypeError: set_pickler() takes exactly one argument (0 given)
+    >>> mc.set_pickler(None)
+    True
+    >>> mc.get("key")
+    Traceback (most recent call last):
+      ...
+    UnpicklingError: invalid load key, '{'.
+    >>> mc.set_pickler("phpserialize")
+    True
+    >>> mc.get("key")
+    Traceback (most recent call last):
+      ...
+    ValueError: unexpected opcode
+    >>> mc.set("key", {"complex": True})
+    True
+    >>> mc.get("key")
+    {'complex': True}
+    >>> mc.set_pickler("json")
+    True
+    >>> mc.get("key")
+    Traceback (most recent call last):
+      ...
+    ValueError: No JSON object could be decoded
+    >>> mc.set("key", {"complex": True})
+    True
+    >>> mc.get("key")
+    {u'complex': True}
+    >>> mc.set_pickler("time")
+    Traceback (most recent call last):
+      ...
+    ImportError: Invalid pickler: time. The module must exist and must support both .loads() and .dumps() functions.
+    >>> mc.get("key")
+    '{"complex": true}'
+    >>> mc.set("key", {"complex": True})
+    False
+    >>> mc.get("key")
+    '{"complex": true}'
+
 Further Reading
 ===============
 


### PR DESCRIPTION
Support custom serializer

Adds the ability to override the serializer used when storing
and retrieving data in cache.  Any serializing module can be used,
as long as it follows the standard Python serializing interface,
supporting a minimum of loads(str) and dumps(obj)::

    client = pylibmc.Client(servers)
    client.set_pickler("json")

    client.set('foo', value)
    value = client.get('foo')

Works like, e.g.::

    import json
    client.set('foo', json.dumps(value))
    value = json.loads(client.get('foo'))

The difference is that using `pylibmc.Client.set_pickler()`,
the value will be set in cache with the "serialized" flag, indicating
to other clients that the value is a serialized string, and it should
attempt to deserialize it before use.

By supporting other serializers, pylibmc can share its cache with clients
in other languages, such as PHP (pecl-memcached supports both PHP and JSON
serializers, both of which can also be used with Python modules):

 * cPickle
 * pickle
 * phpserialize
 * json
 * yaml
 * marshall
 * etc...

This commit also includes doctests for the pickler functionality.  And part of the change is to cache the module and loads/dumps attributes in the client instance itself, so that each call to the pickler/unpickler does not have to do additional imports and attribute lookups.