### PR TITLE
Support for weights on servers

### DIFF
--- a/_pylibmcmodule.c
+++ b/_pylibmcmodule.c
@@ -139,9 +139,11 @@ static int PylibMC_Client_init(PylibMC_Client *self, PyObject *args,
         unsigned char stype;
         char *hostname;
         unsigned short int port;
+        unsigned short int weight;
 
         got_server |= 1;
         port = 0;
+        weight = 1;
         if (PyString_Check(c_srv)) {
             memcached_server_st *list;
 
@@ -153,12 +155,12 @@ static int PylibMC_Client_init(PylibMC_Client *self, PyObject *args,
             }
 
             rc = memcached_server_push(self->mc, list);
-            free(list);
+            memcached_server_list_free(list);
             if (rc != MEMCACHED_SUCCESS) {
                 PylibMC_ErrFromMemcached(self, "memcached_server_push", rc);
                 goto it_error;
             }
-        } else if (PyArg_ParseTuple(c_srv, "Bs|H", &stype, &hostname, &port)) {
+        } else if (PyArg_ParseTuple(c_srv, "Bs|HH", &stype, &hostname, &port, &weight)) {
             if (set_stype && set_stype != stype) {
                 PyErr_SetString(PyExc_ValueError, "can't mix transport types");
                 goto it_error;
@@ -177,10 +179,10 @@ static int PylibMC_Client_init(PylibMC_Client *self, PyObject *args,
 
             switch (stype) {
                 case PYLIBMC_SERVER_TCP:
-                    rc = memcached_server_add(self->mc, hostname, port);
+                    rc = memcached_server_add_with_weight(self->mc, hostname, port, weight);
                     break;
                 case PYLIBMC_SERVER_UDP:
-                    rc = memcached_server_add_udp(self->mc, hostname, port);
+                    rc = memcached_server_add_udp_with_weight(self->mc, hostname, port, weight);
                     break;
                 case PYLIBMC_SERVER_UNIX:
                     if (port) {
@@ -188,7 +190,7 @@ static int PylibMC_Client_init(PylibMC_Client *self, PyObject *args,
                                 "can't set port on unix sockets");
                         goto it_error;
                     }
-                    rc = memcached_server_add_unix_socket(self->mc, hostname);
+                    rc = memcached_server_add_unix_socket_with_weight(self->mc, hostname, weight);
                     break;
                 default:
                     PyErr_Format(PyExc_ValueError, "bad type: %u", stype);

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -4,16 +4,29 @@ import _pylibmc
 
 def test_translate():
     eq_(translate_server_spec("111.122.133.144"),
-        (_pylibmc.server_type_tcp, "111.122.133.144", 11211))
+        (_pylibmc.server_type_tcp, "111.122.133.144", 11211, 1))
 
 def test_translate():
     eq_(translate_server_spec("111.122.133.144:5555"),
-        (_pylibmc.server_type_tcp, "111.122.133.144", 5555))
+        (_pylibmc.server_type_tcp, "111.122.133.144", 5555, 1))
 
 def test_udp_translate():
     eq_(translate_server_spec("udp:199.299.399.499:5555"),
-        (_pylibmc.server_type_udp, "199.299.399.499", 5555))
+        (_pylibmc.server_type_udp, "199.299.399.499", 5555, 1))
 
 def test_udp_translate_ipv6():
     eq_(translate_server_spec("udp:[abcd:abcd::1]:5555"),
-        (_pylibmc.server_type_udp, "abcd:abcd::1", 5555))
+        (_pylibmc.server_type_udp, "abcd:abcd::1", 5555, 1))
+
+def test_translate_with_weight_string():
+    eq_(translate_server_spec("111.122.133.144:5555:2"),
+        (_pylibmc.server_type_tcp, "111.122.133.144", 5555, 2))
+
+def test_translate_with_weight_kwd():
+    eq_(translate_server_spec("111.122.133.144", weight=2),
+        (_pylibmc.server_type_tcp, "111.122.133.144", 11211, 2))
+
+def test_udp_translate_ipv6_with_weight():
+    eq_(translate_server_spec("udp:[abcd:abcd::1]:5555:2"),
+        (_pylibmc.server_type_udp, "abcd:abcd::1", 5555, 2))
+


### PR DESCRIPTION
The current server list parsing is lacking the ability to specify a weight for individual servers in the pool.  The `memcached_servers_parse()` function in libmemcached does support the format "`addr:port:weight`" for TCP servers, however, pylibmc does not accept that format (additionally `memcached_servers_parse()` is [documented](http://docs.libmemcached.org/memcached_server_st.html) as "DEPRECATED").

This change adds support for the `addr:port:weight` format, and also allows passing the weight explicitly to `translate_server_spec()`, and adding weight into the server list tuple.

Unit tests have been updated to reflect the changes.
