### PR TITLE
MEMCACHED_BEHAVIOR_TCP_KEEPALIVE and MEMCACHED_CALLBACK_PREFIX_KEY

### DIFF
--- a/_pylibmcmodule.h
+++ b/_pylibmcmodule.h
@@ -209,6 +209,10 @@ static PylibMC_Behavior PylibMC_behaviors[] = {
     { 0, NULL }
 };
 
+static PylibMC_Behavior PylibMC_callbacks[] = {
+    { MEMCACHED_CALLBACK_PREFIX_KEY, "prefix_key" },
+    { 0, NULL }
+};
 static PylibMC_Behavior PylibMC_hashers[] = {
     { MEMCACHED_HASH_DEFAULT, "default" },
     { MEMCACHED_HASH_MD5, "md5" },

--- a/pylibmc/client.py
+++ b/pylibmc/client.py
@@ -3,9 +3,10 @@
 import _pylibmc
 from .consts import (hashers, distributions, all_behaviors,
                      hashers_rvs, distributions_rvs,
-                     BehaviorDict)
+                     all_callbacks, BehaviorDict)
 
 _all_behaviors_set = set(all_behaviors)
+_all_behaviors_set.update(set(all_callbacks))
 
 server_type_map = {"tcp":   _pylibmc.server_type_tcp,
                    "udp":   _pylibmc.server_type_udp,

--- a/pylibmc/consts.py
+++ b/pylibmc/consts.py
@@ -14,6 +14,7 @@ for name, exc in _pylibmc.exceptions:
     setattr(modpkg, name, exc)
 
 all_behaviors = _pylibmc.all_behaviors
+all_callbacks = _pylibmc.all_callbacks
 hashers, hashers_rvs = {}, {}
 distributions, distributions_rvs = {}, {}
 # Not the prettiest way of doing things, but works well.


### PR DESCRIPTION
pylibmc currently supports a "key_prefix" option in cache gets and sets, but that must be done manually on every request.  libmemcached supports a prefix key "callback", which allows libmemcached to do the JIT modifications to the cache keys.

To keep the implementation simple, I've inserted the callbacks into the set_behaviors() functionality, so that it works more like pecl-memcached's setOption() feature, which can do behaviors, callbacks, and set internal extension options.

This commit also adds the "tcp_keepalive" behavior.

```
>>> c = pylibmc.Client(servers=['127.0.0.1'])
>>> c.set('foo:bar', 'This is set as foo:bar.')
True
>>> c.set('bar', 'This is set as bar.')
True
>>> c.set_behaviors({"prefix_key": "foo:"})
>>> print c.get('foo:bar')
None
>>> c.get('bar')
'This is set as foo:bar.'
```
