### PR TITLE
Allow subclasses to override the deserialization logic

### DIFF
--- a/_pylibmcmodule.c
+++ b/_pylibmcmodule.c
@@ -464,6 +464,7 @@ static PyObject *PylibMC_Client_get(PylibMC_Client *self, PyObject *arg) {
         if (r == NULL && PyErr_Occurred() && PyErr_ExceptionMatches(PylibMCExc_CacheMiss)) {
             /* Since python-memcache returns None when the key doesn't exist,
              * so shall we. */
+            PyErr_Clear();
             Py_RETURN_NONE;
         };
         return r;
@@ -1417,6 +1418,7 @@ static PyObject *PylibMC_Client_get_multi(
         if (val == NULL) {
             if (PyErr_Occurred() && PyErr_ExceptionMatches(PylibMCExc_CacheMiss)) {
                 Py_DECREF(key_obj);
+                PyErr_Clear();
                 continue;
             } else {
                 goto unpack_error;

--- a/_pylibmcmodule.h
+++ b/_pylibmcmodule.h
@@ -115,6 +115,7 @@ typedef struct {
 
 /* {{{ Exceptions */
 static PyObject *PylibMCExc_MemcachedError;
+static PyObject *PylibMCExc_CacheMiss;
 
 /* Mapping of memcached_return value -> Python exception object. */
 typedef struct {
@@ -247,6 +248,7 @@ static PylibMC_Client *PylibMC_ClientType_new(PyTypeObject *, PyObject *,
         PyObject *);
 static void PylibMC_ClientType_dealloc(PylibMC_Client *);
 static int PylibMC_Client_init(PylibMC_Client *, PyObject *, PyObject *);
+static PyObject *PylibMC_Client_deserialize(PylibMC_Client *, PyObject *arg);
 static PyObject *PylibMC_Client_get(PylibMC_Client *, PyObject *arg);
 static PyObject *PylibMC_Client_gets(PylibMC_Client *, PyObject *arg);
 static PyObject *PylibMC_Client_set(PylibMC_Client *, PyObject *, PyObject *);
@@ -273,7 +275,6 @@ static PyObject *PylibMC_ErrFromMemcachedWithKey(PylibMC_Client *, const char *,
         memcached_return, const char *, Py_ssize_t);
 static PyObject *PylibMC_ErrFromMemcached(PylibMC_Client *, const char *,
         memcached_return);
-static PyObject *_PylibMC_Unpickle(const char *, size_t);
 static PyObject *_PylibMC_Pickle(PyObject *);
 static int _PylibMC_CheckKey(PyObject *);
 static int _PylibMC_CheckKeyStringAndSize(char *, Py_ssize_t);
@@ -299,6 +300,10 @@ static bool _PylibMC_IncrDecr(PylibMC_Client *, pylibmc_incr *, size_t);
 
 /* {{{ Type's method table */
 static PyMethodDef PylibMC_ClientType_methods[] = {
+    {"deserialize", (PyCFunction)PylibMC_Client_deserialize, METH_O,
+        "Deserialize a bytestring (str) retrieved from memcached. The default "
+        "implementation uses `cPickle.loads`. Raise pylibmc.CacheMiss to "
+        "simulate a cache miss."},
     {"get", (PyCFunction)PylibMC_Client_get, METH_O,
         "Retrieve a key from a memcached."},
     {"gets", (PyCFunction)PylibMC_Client_gets, METH_O,
@@ -405,3 +410,4 @@ static PyTypeObject PylibMC_ClientType = {
 /* }}} */
 
 #endif /* def __PYLIBMC_H__ */
+// vim:et:sts=4:sw=4:

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -20,3 +20,49 @@ class ClientTests(PylibmcTestCase):
             ok_(mc.cas(k, rv + 1, cas))
             if rv == 10:
                 break
+
+
+    def test_override_deserialize(self):
+        class MyClient(pylibmc.Client):
+            ignored = []
+            def deserialize(self, bytes):
+                try:
+                    return super(MyClient, self).deserialize(bytes)
+                except Exception, error:
+                    self.ignored.append(error)
+                    raise pylibmc.CacheMiss
+
+        global MyObject # Needed by the pickling system.
+        class MyObject(object):
+            def __getstate__(self):
+                return dict(a=1)
+            def __eq__(self, other):
+                return type(other) is type(self)
+            def __setstate__(self, d):
+                assert d['a'] == 1
+
+        c = make_test_client(MyClient)
+        eq_(c.get('notathing'), None)
+
+        c['foo'] = 'foo'
+        c['myobj'] = MyObject()
+        c['noneobj'] = None
+
+        # Show that everything is initially regular.
+        eq_(c.get('myobj'), MyObject())
+        eq_(c.get_multi(['foo', 'myobj', 'noneobj', 'cachemiss']),
+                dict(foo='foo', myobj=MyObject(), noneobj=None))
+
+        # Show that the subclass can transform unpickling issues into a cache misses.
+        del MyObject # Break unpickling
+
+        eq_(c.get('myobj'), None)
+        eq_(c.get_multi(['foo', 'myobj', 'noneobj', 'cachemiss']),
+                dict(foo='foo', noneobj=None))
+
+        # The ignored errors are "AttributeError: test.test_client has no MyObject"
+        eq_(len(MyClient.ignored), 2)
+        assert all(isinstance(error, AttributeError) for error in MyClient.ignored)
+
+
+# vim:et:sts=4:sw=4:


### PR DESCRIPTION
This matches https://github.com/lericson/pylibmc/issues/96

I've added a unit test which demonstrates how this can be used to transform unpickling errors to cache misses. This is implemented by refactoring the `_PylibMC_Unpickle` function to be a method: `Client.deserialize`.

I imagine the next logical step is to do the same refactorization for `_PylibMC_Pickle` / `serialize`, but the project is in a fully usable state as-is, and this change closes our issue. Allowing overrides to both serialize/deserialize will close a couple of your other issues: "Custom Pickler implementations", "It should be possible to specify pickle protocol version".