### PR TITLE
Proposed fix for issue #112

### DIFF
--- a/src/_pylibmcmodule.c
+++ b/src/_pylibmcmodule.c
@@ -1743,7 +1743,11 @@ error:
 
 static memcached_return
 _PylibMC_AddServerCallback(memcached_st *mc,
+#if LIBMEMCACHED_VERSION_HEX >= 0x00039000
+                           memcached_server_instance_st instance,
+#else
                            memcached_server_st *server,
+#endif
                            void *user) {
     _PylibMC_StatsContext *context = (_PylibMC_StatsContext *)user;
     PylibMC_Client *self = (PylibMC_Client *)context->self;
@@ -1788,7 +1792,7 @@ _PylibMC_AddServerCallback(memcached_st *mc,
 
     desc = PyString_FromFormat("%s:%d (%u)",
 #if LIBMEMCACHED_VERSION_HEX >= 0x00039000 
-            memcached_server_name(server), memcached_server_port(server),
+            memcached_server_name(instance), memcached_server_port(instance),
 #else /* ver < libmemcached 0.39 */
             server->hostname, server->port,
 #endif


### PR DESCRIPTION
The memcached_server_function callback was changed in libmemcached-0.39 to take a memcached_server_instance_st as its secont argument instead of memcached_server_st*. My fix adds conditional changes that select the proper interface based on the libmemcached version it is being linked with.
