### PR TITLE
Fixing a crash in set_multi with unicode keys

### DIFF
--- a/src/_pylibmcmodule.c
+++ b/src/_pylibmcmodule.c
@@ -649,6 +649,8 @@ static PyObject *_PylibMC_RunSetCommandMulti(PylibMC_Client *self,
 
         if (!success || PyErr_Occurred() != NULL) {
             /* exception should already be on the stack */
+            /* free only the object we have allocated */
+            nkeys = idx + 1;
             goto cleanup;
         }
     }


### PR DESCRIPTION
When set_multi is called with multiple keys and the keys are
not string (aka they do not serialize well) the code tries
to clean up datastructures that were not initialized.
This causes segmentation fault. Basically we should only
clean up the objects we have allocated.

fix for issue #116
