### PR TITLE
Mention the unit of connect_timeout in docs.

### DIFF
--- a/docs/behaviors.rst
+++ b/docs/behaviors.rst
@@ -84,7 +84,8 @@ libmemcached behavior constants.
 .. _connect_timeout:
 
 ``"connect_timeout"``
-   In non-blocking, mode this specifies the timeout of socket connection.
+   In non-blocking mode, this specifies the timeout of socket connection
+   in milliseconds.
 
 .. _receive_timeout:
 


### PR DESCRIPTION
This patch adds the description of the connect_timeout's unit in docs
like receive_timeout, send_timeout and dead_timeout.
