### PR TITLE
Add tox.ini for tox (http://tox.testrun.org/)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,5 +5,6 @@ docs/_build
 build
 dist
 tmp
+.tox
 MANIFEST
 sendapatch.se

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,7 @@
+[tox]
+envlist = py26, py27
+
+[testenv]
+commands = {toxinidir}/bin/runtests.py {posargs:-v tests --with-doctest}
+deps =
+    nose


### PR DESCRIPTION
[Tox](http://tox.testrun.org/) is a great tool for testing compatibility with various Python versions -- e.g.:

```
marca@marca-mac:~/dev/git-repos/pylibmc$ tox
...
  py26: commands succeeded
  py27: commands succeeded
  pypy: commands succeeded
  congratulations :)
```

Note that because of issue #129, I had to remove `setup.cfg` for this to work.
