### PR TITLE
Add a typedef for memcached_server_instance_st when LIBMEMCACHED_VERSION_HEX > 0x01000009

### DIFF
--- a/src/_pylibmcmodule.c
+++ b/src/_pylibmcmodule.c
@@ -1838,6 +1838,10 @@ error:
     return NULL;
 }
 
+#if LIBMEMCACHED_VERSION_HEX >= 0x01000009
+typedef const struct memcached_instance_st *memcached_server_instance_st;
+#endif
+
 static memcached_return
 _PylibMC_AddServerCallback(memcached_st *mc,
 #if LIBMEMCACHED_VERSION_HEX >= 0x00039000


### PR DESCRIPTION
Fixes GH-133.

Results with this:

```
(py26.venv)vagrant@lucid64:~/dev/git-repos/pylibmc$ CFLAGS="-I/home/vagrant/sw/include" LDFLAGS="-L/home/vagrant/sw/lib" python setup.py build
running build
running build_py
running build_ext
building '_pylibmc' extension
gcc -pthread -fno-strict-aliasing -DNDEBUG -g -fwrapv -O2 -Wall -Wstrict-prototypes -I/home/vagrant/sw/include -fPIC -DUSE_ZLIB -I/usr/include/python2.6 -c src/_pylibmcmodule.c -o build/temp.linux-x86_64-2.6/src/_pylibmcmodule.o -fno-strict-aliasing
gcc -pthread -shared -Wl,-O1 -Wl,-Bsymbolic-functions -L/home/vagrant/sw/lib -I/home/vagrant/sw/include build/temp.linux-x86_64-2.6/src/_pylibmcmodule.o -lmemcached -lz -o build/lib.linux-x86_64-2.6/_pylibmc.so
(py26.venv)vagrant@lucid64:~/dev/git-repos/pylibmc$ LD_LIBRARY_PATH=/home/vagrant/sw/lib python bin/runtests.py
nose.plugins.pylibmc: INFO: path to dev build: build/lib.linux-x86_64-2.6
nose.plugins.pylibmc: INFO: loaded _pylibmc from build/lib.linux-x86_64-2.6/_pylibmc.so
nose.plugins.pylibmc: INFO: testing pylibmc 1.3.100-dev for libmemcached 1.0.17 (compression=True, sasl=False)
.........E.................
======================================================================
ERROR: test_touch (tests.test_client.ClientTests)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vagrant/dev/git-repos/pylibmc/tests/test_client.py", line 59, in test_touch
    ok_(self.mc.touch("touch-test", 5))
SocketCreateError: error 11 from memcached_touch(touch-test): SUCCESS

----------------------------------------------------------------------
Ran 27 tests in 11.872s

FAILED (errors=1)
```

I am assuming that the test failure is a different issue.
