### PR TITLE
Use memcached_instance_st*  instead of memcached_server_instance_st for libmemcached-1.0.17

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,13 @@
+language: python
+
+python:
+  - 2.5
+  - 2.6
+  - 2.7
+
+install: python setup.py install
+
+before_script:
+  - pip install nose
+
+script: python bin/runtests.py

--- a/tests/doctests.txt
+++ b/tests/doctests.txt
@@ -264,7 +264,7 @@ Traceback (most recent call last):
 ValueError: key too long, max is 250
 
 Make sure ServerDown exception exists
->>> hasattr(pylibmc, 'ServerDown')
+>>> hasattr(pylibmc, 'ServerDown') or _pylibmc.libmemcached_version_hex < 0x01000002
 True
 
 Gets should return (None, None) for non-existing keys

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,9 +1,20 @@
+import functools
 import time
 import pylibmc
 import _pylibmc
 from pylibmc.test import make_test_client
 from tests import PylibmcTestCase
+from nose import SkipTest
 from nose.tools import eq_, ok_
+
+def requires_memcached_touch(test):
+    @functools.wraps(test)
+    def wrapper(*args, **kwargs):
+        if _pylibmc.libmemcached_version_hex >= 0x01000002:
+            return test(*args, **kwargs)
+        raise SkipTest
+
+    return wrapper
 
 class ClientTests(PylibmcTestCase):
     def test_zerokey(self):
@@ -48,6 +59,7 @@ class ClientTests(PylibmcTestCase):
         eq_(sorted_list(expected_behaviors),
             sorted_list(actual_behaviors))
 
+    @requires_memcached_touch
     def test_touch(self):
         ok_(self.mc.set("touch-test", "touch-val", 1))
         eq_("touch-val", self.mc.get("touch-test"))


### PR DESCRIPTION
This is an alternative to PR #134 for fixing GH-133.

Instead of hacking in a typedef, it uses `memcached_instance_st*`, which is the documented type to use for `memcached_server_{name,port}`.

Fixes GH-133.
