### PR TITLE
Fix python 3.x failing to add pylibmc to path for tests

### DIFF
--- a/bin/runtests.py
+++ b/bin/runtests.py
@@ -38,12 +38,10 @@ class PylibmcPlugin(Plugin):
     enableOpt = "info"
 
     def __init__(self):
-        Plugin.__init__(self)
-
-    def begin(self):
         hack_sys_path()
         from pylibmc import build_info
         logger.info("testing %s", build_info())
+        Plugin.__init__(self)
 
 if __name__ == "__main__":
     nose.main(addplugins=[PylibmcPlugin()])


### PR DESCRIPTION
For some reason begin() from the nosetests plugin structure is never run.
This should be harmless. Tested in py 2.6,2.7,3.2,3.3 and 3.4.

Should fix one of the remaining issues in issue #144.
