### PR TITLE
setup.py: explicitly read README.rst as UTF-8

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,10 @@ import os
 import sys
 from distutils.core import setup, Extension
 
+# Need an 'open' function that supports the 'encoding' argument:
+if sys.version_info[0] < 3:
+    from codecs import open
+
 ## Command-line argument parsing
 
 # --with-zlib: use zlib for compressing and decompressing
@@ -91,9 +95,9 @@ if cmd == "gen-setup":
         s.write(line + "\n")
     sys.exit(0)
 
-with open("README.rst", "U") as r:
+with open("README.rst", "U", encoding="utf-8") as r:
     readme_text = r.read()
-with open("src/pylibmc-version.h", "U") as r:
+with open("src/pylibmc-version.h", "U", encoding="utf-8") as r:
     version = r.read().strip().split("\"")[1]
 
 setup(name="pylibmc", version=version,


### PR DESCRIPTION
For whatever reason, Python 3 doesn't assume UTF-8 decoding in Mac OS.
README.rst is encoded as UTF-8, so use this encoding regardless of the
system locale/default encoding.

The builtin `open` function doesn't support an `encoding` argument in
Python 2, though, so swap it out for `codecs.open`.
