### PR TITLE
Fix #161

### DIFF
--- a/src/_pylibmcmodule.c
+++ b/src/_pylibmcmodule.c
@@ -2402,7 +2402,14 @@ static void _make_excs(PyObject *module) {
     PyModule_AddObject(module, "Error",
                        (PyObject *)PylibMCExc_Error);
 
-    /* Backwards compatible name for <= pylibmc 1.2.3 */
+    /* Backwards compatible name for <= pylibmc 1.2.3
+     *
+     * Need to increase the refcount since we're adding another
+     * reference to the exception class. Otherwise, debug builds
+     * of Python dump core with
+     * Modules/gcmodule.c:379: visit_decref: Assertion `((gc)->gc.gc_refs >> (1)) != 0' failed.
+     */
+    Py_INCREF(PylibMCExc_Error);
     PyModule_AddObject(module, "MemcachedError",
                        (PyObject *)PylibMCExc_Error);
 


### PR DESCRIPTION
22333a3221eb5e7f10dd1770fb597d114f27a2c7 added a second reference to `PylibMCExc_Error` without a corresponding `Py_INCREF` call. This is caught by an assertion enabled in debug builds of Python, which causes a core dump as described in #161.

I'm not sure if this is the best place to add this `Py_INCREF` call, but it definitely has to go _somewhere_.
