### PR TITLE
Fix Unix domain socket address spec

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -20,8 +20,8 @@
    To specify UDP, the server address should be prefixed with ``"udp:"``, as in
    ``"udp:127.0.0.1"``.
 
-   To specify UNIX domain socket, the server address must contain a slash, as
-   in ``"./foo.sock"``.
+   To specify UNIX domain socket, the server address must start with a slash, as
+   in ``"/run/foo.sock"``.
 
    Mixing transport types is prohibited by :mod:`pylibmc` as this is not supported by
    libmemcached.


### PR DESCRIPTION
The documentation says "To specify UNIX domain socket, the server address must contain a slash".

The [code](https://github.com/lericson/pylibmc/blob/4633ad70070a70be9727e93e285b3f7e799af6e5/src/pylibmc/client.py#L16) says `spec.startswith("/")`.

One of these is wrong.  I'm guessing it's the documentation, hence this PR.