### PR TITLE
Port sap theme to Sphinx 1.3

### DIFF
--- a/docs/_themes/sap/layout.html
+++ b/docs/_themes/sap/layout.html
@@ -1,3 +1,3 @@
-{% extends "default/layout.html" %}
+{% extends "classic/layout.html" %}
 
 {%- block relbar2 %}<!-- I hate crud -->{% endblock %}

--- a/docs/_themes/sap/static/main.css_t
+++ b/docs/_themes/sap/static/main.css_t
@@ -9,7 +9,7 @@
  *
  */
 
-@import url("default.css");
+@import url("classic.css");
 
 /* -- page layout ----------------------------------------------------------- */
 

--- a/docs/_themes/sap/theme.conf
+++ b/docs/_themes/sap/theme.conf
@@ -1,5 +1,5 @@
 [theme]
-inherit = default
+inherit = classic
 stylesheet = main.css
 pygments_style = sphinx
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -34,7 +34,7 @@ import pylibmc
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '1.3'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.


### PR DESCRIPTION
In Sphinx 1.3, default theme was renamed to classic, so default/layout.html and default.css no longer exist. This is the backported patch from the Debian package bug [#799576](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=799576).