### PR TITLE
custom serialization and deserialization (2015 edition)

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -218,6 +218,34 @@
       not a key exists depends on the version of libmemcached and memcached
       used.
 
+   .. method:: serialize(value) -> bytestring, flag
+
+      Serialize a Python value to bytes *bytestring* and an integer *flag* field
+      for storage in memcached. The default implementation has special cases
+      for bytes, ints/longs, and bools, and falls back to pickle for all other
+      objects. Override this method to use a custom serialization format, or
+      otherwise modify the behavior.
+
+      *flag* is exposed by libmemcached. In this context, it adds flexibility
+      in terms of encoding schemes: for example, objects *a* and *b* of
+      different types may coincidentally encode to the same *bytestring*,
+      just so long as they encode with different values of *flag*. If distinct
+      values always encode to different byte strings (for example, when
+      serializing all values with pickle), *flag* can simply be set to a
+      constant.
+
+   .. method:: deserialize(bytestring, flag) -> value
+
+      Deserialize *bytestring*, stored with *flag*, back to a Python object.
+      Override this method (in concert with ``serialize``) to use a custom
+      serialization format, or otherwise modify the behavior.
+
+      Raise ``CacheMiss`` in order to simulate a cache miss for the relevant
+      key, i.e., ``get`` will return None and ``get_multi`` will omit the key
+      from the returned mapping. This can be used to recover gracefully from
+      version skew (e.g., retrieving a value that was pickled by a different,
+      incompatible code version).
+
    .. data:: behaviors
 
       The behaviors used by the underlying libmemcached object. See

--- a/src/_pylibmcmodule.c
+++ b/src/_pylibmcmodule.c
@@ -2555,7 +2555,7 @@ static void _make_excs(PyObject *module) {
             "pylibmc.Error", NULL, NULL);
 
     PylibMCExc_CacheMiss = PyErr_NewException(
-            "_pylibmc.CacheMiss", NULL, NULL);
+            "_pylibmc.CacheMiss", PylibMCExc_Error, NULL);
 
     exc_objs = PyList_New(0);
     PyList_Append(exc_objs,

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,6 +1,8 @@
 """Tests. They want YOU!!"""
-
 from __future__ import print_function
+
+import gc
+import sys
 import unittest
 import pylibmc
 from pylibmc.test import make_test_client
@@ -29,3 +31,13 @@ def dump_infos():
     print("Reported libmemcached version:", _pylibmc.libmemcached_version)
     print("Reported pylibmc version:", _pylibmc.__version__)
     print("Support compression:", _pylibmc.support_compression)
+
+def get_refcounts(refcountables):
+    """Measure reference counts during testing.
+
+    Measuring reference counts typically changes them (since at least
+    one new reference is created as the argument to sys.getrefcount).
+    Therefore, try to do it in a consistent and deterministic fashion.
+    """
+    gc.collect()
+    return [sys.getrefcount(val) for val in refcountables]

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -49,7 +49,7 @@ class RefcountTests(PylibmcTestCase):
 
     def test_get_multi(self):
         bc = make_test_client(binary=True)
-        keys = ["first", "second"]
+        keys = ["first", "second", "", b""]
         value = "first_value"
         refcountables = keys + [value]
         initial_refcounts = get_refcounts(refcountables)

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -47,6 +47,9 @@ class RefcountTests(PylibmcTestCase):
     def test_get_simple(self):
         self._test_get(b"refcountest2", 485295)
 
+    def test_get_singleton(self):
+        self._test_get(b"refcountest3", False)
+
     def test_get_multi(self):
         bc = make_test_client(binary=True)
         keys = ["first", "second", "", b""]

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -10,10 +10,7 @@ import pylibmc
 import _pylibmc
 from pylibmc.test import make_test_client
 from tests import PylibmcTestCase
-
-
-def get_refcounts(refcountables):
-    return [sys.getrefcount(val) for val in refcountables]
+from tests import get_refcounts
 
 
 class RefcountTests(PylibmcTestCase):

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -1,0 +1,181 @@
+from __future__ import unicode_literals
+from __future__ import print_function
+
+import json
+import sys
+
+from nose.tools import eq_, ok_
+
+import pylibmc
+import _pylibmc
+from pylibmc.test import make_test_client
+from tests import PylibmcTestCase
+
+
+def get_refcounts(refcountables):
+    return [sys.getrefcount(val) for val in refcountables]
+
+def long_(val):
+    try:
+        return long(val)
+    except NameError:
+        # this happens under Python 3
+        return val
+
+class SerializationTests(PylibmcTestCase):
+    """Test coverage for overriding serialization behavior in subclasses."""
+
+    def test_override_deserialize(self):
+        class MyClient(pylibmc.Client):
+            ignored = []
+            def deserialize(self, bytes_, flags):
+                try:
+                    return super(MyClient, self).deserialize(bytes_, flags)
+                except Exception as error:
+                    self.ignored.append(error)
+                    raise pylibmc.CacheMiss
+
+        global MyObject # Needed by the pickling system.
+        class MyObject(object):
+            def __getstate__(self):
+                return dict(a=1)
+            def __eq__(self, other):
+                return type(other) is type(self)
+            def __setstate__(self, d):
+                assert d['a'] == 1
+
+        c = make_test_client(MyClient, behaviors={'cas': True})
+        eq_(c.get('notathing'), None)
+
+        refcountables = ['foo', 'myobj', 'noneobj', 'myobj2', 'cachemiss', None]
+        initial_refcounts = get_refcounts(refcountables)
+
+        c['foo'] = 'foo'
+        c['myobj'] = MyObject()
+        c['noneobj'] = None
+        c['myobj2'] = MyObject()
+
+        # Show that everything is initially regular.
+        eq_(c.get('myobj'), MyObject())
+        eq_(get_refcounts(refcountables), initial_refcounts)
+        eq_(c.get_multi(['foo', 'myobj', 'noneobj', 'cachemiss']),
+                dict(foo='foo', myobj=MyObject(), noneobj=None))
+        eq_(get_refcounts(refcountables), initial_refcounts)
+        eq_(c.gets('myobj2')[0], MyObject())
+        eq_(get_refcounts(refcountables), initial_refcounts)
+
+        # Show that the subclass can transform unpickling issues into a cache miss.
+        del MyObject # Break unpickling
+
+        eq_(c.get('myobj'), None)
+        eq_(get_refcounts(refcountables), initial_refcounts)
+        eq_(c.get_multi(['foo', 'myobj', 'noneobj', 'cachemiss']),
+                dict(foo='foo', noneobj=None))
+        eq_(get_refcounts(refcountables), initial_refcounts)
+        eq_(c.gets('myobj2'), (None, None))
+        eq_(get_refcounts(refcountables), initial_refcounts)
+
+        # The ignored errors are "AttributeError: test.test_client has no MyObject"
+        eq_(len(MyClient.ignored), 3)
+        assert all(isinstance(error, AttributeError) for error in MyClient.ignored)
+
+    def test_refcounts(self):
+        SENTINEL = object()
+        DUMMY = b"dummy"
+        KEY = b"fwLiDZKV7IlVByM5bVDNkg"
+        VALUE = "PVILgNVNkCfMkQup5vkGSQ"
+
+        class MyClient(_pylibmc.client):
+            """Always serialize and deserialize to the same constants."""
+
+            def serialize(self, value):
+                return DUMMY, 1
+
+            def deserialize(self, bytes_, flags):
+                return SENTINEL
+
+        refcountables = [1, long_(1), SENTINEL, DUMMY, KEY, VALUE]
+        c = make_test_client(MyClient)
+        initial_refcounts = get_refcounts(refcountables)
+
+        c.set(KEY, VALUE)
+        eq_(get_refcounts(refcountables), initial_refcounts)
+        assert c.get(KEY) is SENTINEL
+        eq_(get_refcounts(refcountables), initial_refcounts)
+        eq_(c.get_multi([KEY]), {KEY: SENTINEL})
+        eq_(get_refcounts(refcountables), initial_refcounts)
+        c.set_multi({KEY: True})
+        eq_(get_refcounts(refcountables), initial_refcounts)
+
+    def test_override_serialize(self):
+        class MyClient(pylibmc.Client):
+            def serialize(self, value):
+                return json.dumps(value).encode('utf-8'), 0
+
+            def deserialize(self, bytes_, flags):
+                return json.loads(bytes_.decode('utf-8'))
+
+        c = make_test_client(MyClient)
+        c['foo'] = (1, 2, 3, 4)
+        # json turns tuples into lists:
+        eq_(c['foo'], [1, 2, 3, 4])
+
+        raised = False
+        try:
+            c['bar'] = object()
+        except TypeError:
+            raised = True
+        assert raised
+
+    def _assert_set_raises(self, client, key, value):
+        """Assert that set operations raise a ValueError when appropriate.
+
+        This is in a separate method to avoid confusing the reference counts.
+        """
+        raised = False
+        try:
+            client[key] = value
+        except ValueError:
+            raised = True
+        assert raised
+
+    def test_invalid_flags_returned(self):
+        # test that nothing bad (memory leaks, segfaults) happens
+        # when subclasses implement `deserialize` incorrectly
+        DUMMY = b"dummy"
+        BAD_FLAGS = object()
+        KEY = 'foo'
+        VALUE = object()
+        refcountables = [KEY, DUMMY, VALUE, BAD_FLAGS]
+
+        class MyClient(pylibmc.Client):
+            def serialize(self, value):
+                return DUMMY, BAD_FLAGS
+
+        c = make_test_client(MyClient)
+        initial_refcounts = get_refcounts(refcountables)
+        self._assert_set_raises(c, KEY, VALUE)
+        eq_(get_refcounts(refcountables), initial_refcounts)
+
+    def test_invalid_flags_returned_2(self):
+        DUMMY = "ab"
+        KEY = "key"
+        VALUE = 123456
+        refcountables = [DUMMY, KEY, VALUE]
+
+        class MyClient(pylibmc.Client):
+            def serialize(self, value):
+                return DUMMY
+
+        c = make_test_client(MyClient)
+        initial_refcounts = get_refcounts(refcountables)
+
+        self._assert_set_raises(c, KEY, VALUE)
+        eq_(get_refcounts(refcountables), initial_refcounts)
+
+        try:
+            c.set_multi({KEY: DUMMY})
+        except ValueError:
+            raised = True
+        assert raised
+        eq_(get_refcounts(refcountables), initial_refcounts)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -10,10 +10,7 @@ import pylibmc
 import _pylibmc
 from pylibmc.test import make_test_client
 from tests import PylibmcTestCase
-
-
-def get_refcounts(refcountables):
-    return [sys.getrefcount(val) for val in refcountables]
+from tests import get_refcounts
 
 def long_(val):
     try:
@@ -47,7 +44,7 @@ class SerializationTests(PylibmcTestCase):
         c = make_test_client(MyClient, behaviors={'cas': True})
         eq_(c.get('notathing'), None)
 
-        refcountables = ['foo', 'myobj', 'noneobj', 'myobj2', 'cachemiss', None]
+        refcountables = ['foo', 'myobj', 'noneobj', 'myobj2', 'cachemiss']
         initial_refcounts = get_refcounts(refcountables)
 
         c['foo'] = 'foo'


### PR DESCRIPTION
cc @bukzor

There are two commits in this PR. One is minor cleanup to some error-handling logic in the get_multi implementation. (I can split that out into a different PR.)

The main change is derived from #102 and incorporates the discussion from #75: it makes serialization and deserialization customizable by overriding methods in a client subclass. The current C implementations have become the `serialize` and `deserialize` methods of `_pylibmc.client`; instead of dispatching to them via C function calls, it is now necessary to dispatch to them via `PyObject_CallMethod`, even in the normal case where they are not overridden.

I have [before-and-after benchmarks](https://gist.github.com/slingamn/92aeda1056914efb4ece) showing a small slowdown, at a low order of magnitude (apparently a few microseconds). The additional overhead is basically just:

1. boxing and unboxing the `flags` value in a Python integer
2. boxing and unboxing the serialized bytes together with `flags` in a tuple
3. method dispatch magic

This should all be pretty cheap. (I might be able to recover some of the lost time by caching the values of `cPickle.dumps` and `cPickle.loads` in `static PyObject *` variables; right now we do an import and a getattr every time.)

Subclasses can raise `CacheMiss` to indicate that a retrieved value should be treated as though it were a miss. The reason it is necessary to do this, rather than having them return `None`, is because of ambiguities in the API inherited from python-memcache. pylibmc allows clients to set a `None` value (the pickle of `None` will be set in memcached), but such a value cannot be retrieved via `get` or `__getitem__` in a way that distinguishes it from a cache miss. Specifically, in both cases, `get` will return `None` and `__getitem__` will raise a `KeyError`. However, a stored `None` can be retrieved via `get_multi`, which will return a dictionary mapping the relevant key to `None`. In contrast, when a key misses under `get_multi`, the key will not appear in the result dictionary at all. Thus, with respect to `get_multi` (and some other APIs), there's a need to distinguish `None` from a miss.

Thanks for your time!