### PR TITLE
Eliminate Python dispatch from (de)serialization

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -220,13 +220,12 @@
 
    .. method:: serialize(value) -> bytestring, flag
 
-      Serialize a Python value to bytes *bytestring* and an integer *flag* field
-      for storage in memcached. The default implementation has special cases
-      for bytes, ints/longs, and bools, and falls back to pickle for all other
-      objects. Override this method to use a custom serialization format, or
-      otherwise modify the behavior.
+      Implement this method in order to change the default serialization
+      implementation. This method takes a Python value and returns bytes
+      *bytestring* and an integer *flag* field for storage in memcached.
+      Call the *_serialize* method to access the default behavior.
 
-      *flag* is exposed by libmemcached. In this context, it adds flexibility
+      *flag* is exposed by the memcached protocol. It adds flexibility
       in terms of encoding schemes: for example, objects *a* and *b* of
       different types may coincidentally encode to the same *bytestring*,
       just so long as they encode with different values of *flag*. If distinct
@@ -236,9 +235,10 @@
 
    .. method:: deserialize(bytestring, flag) -> value
 
-      Deserialize *bytestring*, stored with *flag*, back to a Python object.
-      Override this method (in concert with ``serialize``) to use a custom
-      serialization format, or otherwise modify the behavior.
+      Implement this method in order to change the default serialization
+      implementation. This method takes *bytestring* and *flag*, stored
+      in memcached, and deserializes them back to a Python object.
+      Call the *_deserialize* method to access the default behavior.
 
       Raise ``CacheMiss`` in order to simulate a cache miss for the relevant
       key, i.e., ``get`` will return None and ``get_multi`` will omit the key

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -220,10 +220,11 @@
 
    .. method:: serialize(value) -> bytestring, flag
 
-      Implement this method in order to change the default serialization
-      implementation. This method takes a Python value and returns bytes
-      *bytestring* and an integer *flag* field for storage in memcached.
-      Call the *_serialize* method to access the default behavior.
+      Serialize a Python value to bytes *bytestring* and an integer *flag* field
+      for storage in memcached. The default implementation has special cases
+      for bytes, ints/longs, and bools, and falls back to pickle for all other
+      objects. Override this method to use a custom serialization format, or
+      otherwise modify the behavior.
 
       *flag* is exposed by the memcached protocol. It adds flexibility
       in terms of encoding schemes: for example, objects *a* and *b* of
@@ -235,10 +236,9 @@
 
    .. method:: deserialize(bytestring, flag) -> value
 
-      Implement this method in order to change the default serialization
-      implementation. This method takes *bytestring* and *flag*, stored
-      in memcached, and deserializes them back to a Python object.
-      Call the *_deserialize* method to access the default behavior.
+      Deserialize *bytestring*, stored with *flag*, back to a Python object.
+      Override this method (in concert with ``serialize``) to use a custom
+      serialization format, or otherwise modify the behavior.
 
       Raise ``CacheMiss`` in order to simulate a cache miss for the relevant
       key, i.e., ``get`` will return None and ``get_multi`` will omit the key

--- a/src/_pylibmcmodule.c
+++ b/src/_pylibmcmodule.c
@@ -79,7 +79,6 @@
 #define PyBytes_GET_SIZE PyString_GET_SIZE
 #define PyBytes_Size PyString_Size
 #define PyLong_AS_LONG PyInt_AS_LONG
-#define PyNumber_Long PyNumber_Int
 #define _PyBytes_Resize _PyString_Resize
 #define PyObject_Bytes PyObject_Str
 #endif

--- a/src/_pylibmcmodule.c
+++ b/src/_pylibmcmodule.c
@@ -1218,19 +1218,19 @@ static int _PylibMC_serialize_native(PylibMC_Client *self, PyObject *value_obj, 
         /* Make store_val an owned reference */
         store_val = value_obj;
         Py_INCREF(store_val);
-#if PY_MAJOR_VERSION >= 3
     } else if (PyBool_Check(value_obj)) {
         store_flags |= PYLIBMC_FLAG_BOOL;
-        store_val = PyBytes_FromFormat("%ld", PyLong_AsLong(value_obj));
+        /* bool cannot be subclassed; there are only two singleton values,
+           Py_True and Py_False */
+        const char *value_str = (value_obj == Py_True) ? "1" : "0";
+        store_val = PyBytes_FromString(value_str);
+#if PY_MAJOR_VERSION >= 3
     } else if (PyLong_Check(value_obj)) {
         store_flags |= PYLIBMC_FLAG_LONG;
-        store_val = PyBytes_FromFormat("%ld", PyLong_AsLong(value_obj));
-#else
-    } else if (PyBool_Check(value_obj)) {
-        store_flags |= PYLIBMC_FLAG_BOOL;
-        PyObject* tmp = PyNumber_Long(value_obj);
-        store_val = PyObject_Bytes(tmp);
+        PyObject *tmp = PyObject_Str(value_obj);
+        store_val = PyUnicode_AsEncodedString(tmp, "ascii", "strict");
         Py_DECREF(tmp);
+#else
     } else if (PyInt_Check(value_obj)) {
         store_flags |= PYLIBMC_FLAG_INTEGER;
         PyObject* tmp = PyNumber_Int(value_obj);

--- a/src/_pylibmcmodule.h
+++ b/src/_pylibmcmodule.h
@@ -282,6 +282,8 @@ static PylibMC_Client *PylibMC_ClientType_new(PyTypeObject *, PyObject *,
         PyObject *);
 static void PylibMC_ClientType_dealloc(PylibMC_Client *);
 static int PylibMC_Client_init(PylibMC_Client *, PyObject *, PyObject *);
+static PyObject *PylibMC_Client_deserialize(PylibMC_Client *, PyObject *arg);
+static PyObject *PylibMC_Client_serialize(PylibMC_Client *, PyObject *val);
 static PyObject *PylibMC_Client_get(PylibMC_Client *, PyObject *arg);
 static PyObject *PylibMC_Client_gets(PylibMC_Client *, PyObject *arg);
 static PyObject *PylibMC_Client_set(PylibMC_Client *, PyObject *, PyObject *);
@@ -315,8 +317,6 @@ static PyObject *_PylibMC_Unpickle_Bytes(PyObject *);
 static PyObject *_PylibMC_Pickle(PyObject *);
 static int _key_normalized_obj(PyObject **);
 static int _key_normalized_str(char **, Py_ssize_t *);
-static PyObject *PylibMC_Client__serialize(PylibMC_Client *self, PyObject *value_obj);
-static PyObject *PylibMC_Client__deserialize(PylibMC_Client *self, PyObject *value_obj);
 static int _PylibMC_serialize_user(PylibMC_Client *, PyObject *, PyObject **, uint32_t *);
 static int _PylibMC_serialize_native(PylibMC_Client *, PyObject *, PyObject **, uint32_t *);
 static PyObject *_PylibMC_deserialize_native(PylibMC_Client *, PyObject *, char *, size_t, uint32_t);
@@ -348,6 +348,12 @@ static bool _PylibMC_IncrDecr(PylibMC_Client *, pylibmc_incr *, size_t);
 
 /* {{{ Type's method table */
 static PyMethodDef PylibMC_ClientType_methods[] = {
+    {"serialize", (PyCFunction)PylibMC_Client_serialize, METH_O,
+        "Serialize an object to a byte string and flag field, to be stored "
+         "in memcached."},
+    {"deserialize", (PyCFunction)PylibMC_Client_deserialize, METH_VARARGS,
+        "Deserialize a bytestring and flag field retrieved from memcached. "
+        "Raise pylibmc.CacheMiss to simulate a cache miss."},
     {"get", (PyCFunction)PylibMC_Client_get, METH_O,
         "Retrieve a key from a memcached."},
     {"gets", (PyCFunction)PylibMC_Client_gets, METH_O,
@@ -397,10 +403,6 @@ static PyMethodDef PylibMC_ClientType_methods[] = {
         "another thread. This creates a new connection."},
     {"touch", (PyCFunction)PylibMC_Client_touch, METH_VARARGS,
         "Change the TTL of a key."},
-    {"_serialize", (PyCFunction)PylibMC_Client__serialize, METH_O,
-        "Python binding for the default serialization behavior."},
-    {"_deserialize", (PyCFunction)PylibMC_Client__deserialize, METH_VARARGS,
-        "Python binding for the default deserialization behavior."},
     {NULL, NULL, 0, NULL}
 };
 /* }}} */

--- a/src/_pylibmcmodule.h
+++ b/src/_pylibmcmodule.h
@@ -273,6 +273,8 @@ typedef struct {
     PyObject_HEAD
     memcached_st *mc;
     uint8_t sasl_set;
+    uint8_t native_serialization;
+    uint8_t native_deserialization;
 } PylibMC_Client;
 
 /* {{{ Prototypes */
@@ -280,8 +282,6 @@ static PylibMC_Client *PylibMC_ClientType_new(PyTypeObject *, PyObject *,
         PyObject *);
 static void PylibMC_ClientType_dealloc(PylibMC_Client *);
 static int PylibMC_Client_init(PylibMC_Client *, PyObject *, PyObject *);
-static PyObject *PylibMC_Client_deserialize(PylibMC_Client *, PyObject *arg);
-static PyObject *PylibMC_Client_serialize(PylibMC_Client *, PyObject *val);
 static PyObject *PylibMC_Client_get(PylibMC_Client *, PyObject *arg);
 static PyObject *PylibMC_Client_gets(PylibMC_Client *, PyObject *arg);
 static PyObject *PylibMC_Client_set(PylibMC_Client *, PyObject *, PyObject *);
@@ -310,10 +310,16 @@ static PyObject *PylibMC_ErrFromMemcachedWithKey(PylibMC_Client *, const char *,
         memcached_return, const char *, Py_ssize_t);
 static PyObject *PylibMC_ErrFromMemcached(PylibMC_Client *, const char *,
         memcached_return);
-static PyObject *_PylibMC_Unpickle(PyObject *);
+static PyObject *_PylibMC_Unpickle(const char *, size_t);
+static PyObject *_PylibMC_Unpickle_Bytes(PyObject *);
 static PyObject *_PylibMC_Pickle(PyObject *);
 static int _key_normalized_obj(PyObject **);
 static int _key_normalized_str(char **, Py_ssize_t *);
+static PyObject *PylibMC_Client__serialize(PylibMC_Client *self, PyObject *value_obj);
+static PyObject *PylibMC_Client__deserialize(PylibMC_Client *self, PyObject *value_obj);
+static int _PylibMC_serialize_user(PylibMC_Client *, PyObject *, PyObject **, uint32_t *);
+static int _PylibMC_serialize_native(PylibMC_Client *, PyObject *, PyObject **, uint32_t *);
+static PyObject *_PylibMC_deserialize_native(PylibMC_Client *, PyObject *, char *, size_t, uint32_t);
 static int _PylibMC_SerializeValue(PylibMC_Client *self,
                                    PyObject *key_obj,
                                    PyObject *key_prefix,
@@ -342,12 +348,6 @@ static bool _PylibMC_IncrDecr(PylibMC_Client *, pylibmc_incr *, size_t);
 
 /* {{{ Type's method table */
 static PyMethodDef PylibMC_ClientType_methods[] = {
-    {"serialize", (PyCFunction)PylibMC_Client_serialize, METH_O,
-        "Serialize an object to a byte string and flag field, to be stored "
-         "in memcached."},
-    {"deserialize", (PyCFunction)PylibMC_Client_deserialize, METH_VARARGS,
-        "Deserialize a bytestring and flag field retrieved from memcached. "
-        "Raise pylibmc.CacheMiss to simulate a cache miss."},
     {"get", (PyCFunction)PylibMC_Client_get, METH_O,
         "Retrieve a key from a memcached."},
     {"gets", (PyCFunction)PylibMC_Client_gets, METH_O,
@@ -397,6 +397,10 @@ static PyMethodDef PylibMC_ClientType_methods[] = {
         "another thread. This creates a new connection."},
     {"touch", (PyCFunction)PylibMC_Client_touch, METH_VARARGS,
         "Change the TTL of a key."},
+    {"_serialize", (PyCFunction)PylibMC_Client__serialize, METH_O,
+        "Python binding for the default serialization behavior."},
+    {"_deserialize", (PyCFunction)PylibMC_Client__deserialize, METH_VARARGS,
+        "Python binding for the default deserialization behavior."},
     {NULL, NULL, 0, NULL}
 };
 /* }}} */

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -25,9 +25,10 @@ class SerializationTests(PylibmcTestCase):
     def test_override_deserialize(self):
         class MyClient(pylibmc.Client):
             ignored = []
+
             def deserialize(self, bytes_, flags):
                 try:
-                    return super(MyClient, self).deserialize(bytes_, flags)
+                    return self._deserialize(bytes_, flags)
                 except Exception as error:
                     self.ignored.append(error)
                     raise pylibmc.CacheMiss
@@ -110,6 +111,7 @@ class SerializationTests(PylibmcTestCase):
                 return json.dumps(value).encode('utf-8'), 0
 
             def deserialize(self, bytes_, flags):
+                assert flags == 0
                 return json.loads(bytes_.decode('utf-8'))
 
         c = make_test_client(MyClient)

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -27,21 +27,21 @@ def long_(val):
 
 
 class SerializationMethodTests(PylibmcTestCase):
-    """Coverage tests for _serialize and _deserialize."""
+    """Coverage tests for serialize and deserialize."""
 
     def test_integers(self):
         c = make_test_client(binary=True)
         if sys.version_info[0] == 3:
-            eq_(c._serialize(1), (b'1', 4))
-            eq_(c._serialize(2**64), (b'18446744073709551616', 4))
+            eq_(c.serialize(1), (b'1', 4))
+            eq_(c.serialize(2**64), (b'18446744073709551616', 4))
         else:
-            eq_(c._serialize(1), (b'1', 2))
-            eq_(c._serialize(2**64), (b'18446744073709551616', 4))
+            eq_(c.serialize(1), (b'1', 2))
+            eq_(c.serialize(2**64), (b'18446744073709551616', 4))
 
-            eq_(c._deserialize(b'1', 2), 1)
+            eq_(c.deserialize(b'1', 2), 1)
 
-        eq_(c._deserialize(b'18446744073709551616', 4), 2**64)
-        eq_(c._deserialize(b'1', 4), long_(1))
+        eq_(c.deserialize(b'18446744073709551616', 4), 2**64)
+        eq_(c.deserialize(b'1', 4), long_(1))
 
     def test_nonintegers(self):
         # tuples (python_value, (expected_bytestring, expected_flags))
@@ -58,8 +58,8 @@ class SerializationMethodTests(PylibmcTestCase):
 
         c = make_test_client(binary=True)
         for value, serialized_value in SERIALIZATION_TEST_VALUES:
-            eq_(c._serialize(value), serialized_value)
-            eq_(c._deserialize(*serialized_value), value)
+            eq_(c.serialize(value), serialized_value)
+            eq_(c.deserialize(*serialized_value), value)
 
 
 class SerializationTests(PylibmcTestCase):
@@ -71,7 +71,7 @@ class SerializationTests(PylibmcTestCase):
 
             def deserialize(self, bytes_, flags):
                 try:
-                    return self._deserialize(bytes_, flags)
+                    return super(MyClient, self).deserialize(bytes_, flags)
                 except Exception as error:
                     self.ignored.append(error)
                     raise pylibmc.CacheMiss


### PR DESCRIPTION
This eliminates the performance regression from #197 by creating separate code paths for "native mode" and "user mode" serialization --- on the native path, the values are not boxed and the overhead of Python method dispatch is not incurred. The expected 3-microsecond saving seems to be achieved: https://gist.github.com/slingamn/c82b82084cf7720acf22

Here's where it gets a little weird / counterintuitive. The client detects whether to use "user mode" by testing, in the constructor, for the existence of attributes named `serialize` and `deserialize`. Therefore, the base class does not implement these methods --- they are instead exposed to Python under the names `_serialize` and `_deserialize`. This isn't ideal. It's also an API break, which makes it convenient that 1.6 hasn't been officially released yet.

Thoughts?