### PR TITLE
Fix overrelease (and simultaneous leak) in _PylibMC_Inflate

### DIFF
--- a/src/_pylibmcmodule.c
+++ b/src/_pylibmcmodule.c
@@ -434,6 +434,7 @@ static int _PylibMC_Inflate(char *value, size_t size,
         /* Fall-through */
         case Z_OK:
             if((tryrealloc = realloc(out, rvalsz << 1)) == NULL || errno == ENOMEM) {
+                if (tryrealloc) out = tryrealloc;
                 *failure_reason = "realloc";
                 rc = Z_MEM_ERROR;
                 goto zerror;
@@ -462,6 +463,7 @@ static int _PylibMC_Inflate(char *value, size_t size,
 
     if(tryrealloc == NULL || errno == ENOMEM) {
         /* we failed to *shrink* the value? */
+        if (tryrealloc) out = tryrealloc;
         *failure_reason = "realloc";
         rc = Z_MEM_ERROR;
         goto error;


### PR DESCRIPTION
Not really sure why the implementation is testing errno
when realloc returns a non-null pointer. Is that an
idiosyncrasy of a particular platform...?

You may even be failing spuriously due to stale errno
values. At least with this change, you won't crash the
process.