### PR TITLE
API changes to `get` and `__getitem__`

### DIFF
--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -35,9 +35,10 @@
 
    .. Reading
 
-   .. method:: get(key) -> value
+   .. method:: get(key[, default]) -> value
 
-      Get *key* if it exists, otherwise ``None``.
+      Get *key* if it exists, otherwise *default*. If *default* is not given,
+      it defaults to ``None``.
 
    .. method:: get_multi(keys[, key_prefix=None]) -> values
 

--- a/src/_pylibmcmodule.h
+++ b/src/_pylibmcmodule.h
@@ -356,7 +356,7 @@ static PyMethodDef PylibMC_ClientType_methods[] = {
     {"deserialize", (PyCFunction)PylibMC_Client_deserialize, METH_VARARGS,
         "Deserialize a bytestring and flag field retrieved from memcached. "
         "Raise pylibmc.CacheMiss to simulate a cache miss."},
-    {"get", (PyCFunction)PylibMC_Client_get, METH_O,
+    {"get", (PyCFunction)PylibMC_Client_get, METH_VARARGS,
         "Retrieve a key from a memcached."},
     {"gets", (PyCFunction)PylibMC_Client_gets, METH_O,
         "Retrieve a key and cas_id from a memcached."},

--- a/src/pylibmc/client.py
+++ b/src/pylibmc/client.py
@@ -170,7 +170,7 @@ class Client(_pylibmc.client):
             raise KeyError(key)
 
     def __contains__(self, key):
-        return self.get(key) is not None
+        return self.get(key, _MISS_SENTINEL) is not _MISS_SENTINEL
     # }}}
 
     # {{{ Behaviors

--- a/src/pylibmc/client.py
+++ b/src/pylibmc/client.py
@@ -12,6 +12,8 @@ server_type_map = {"tcp":   _pylibmc.server_type_tcp,
                    "udp":   _pylibmc.server_type_udp,
                    "unix":  _pylibmc.server_type_unix}
 
+_MISS_SENTINEL = object()
+
 def _split_spec_type(spec):
     if spec.startswith("/"):
         return ("unix", spec)
@@ -153,8 +155,8 @@ class Client(_pylibmc.client):
 
     # {{{ Mapping interface
     def __getitem__(self, key):
-        value = self.get(key)
-        if value is None:
+        value = self.get(key, _MISS_SENTINEL)
+        if value is _MISS_SENTINEL:
             raise KeyError(key)
         else:
             return value

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,3 +110,4 @@ class ClientTests(PylibmcTestCase):
         self.assertEqual(mc.get('none-test', 'default'), None)
         # formerly, this would raise a KeyError, which was incorrect
         self.assertEqual(mc['none-test'], None)
+        self.assertIn('none-test', mc)

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -110,4 +110,4 @@ class ClientTests(PylibmcTestCase):
         self.assertEqual(mc.get('none-test', 'default'), None)
         # formerly, this would raise a KeyError, which was incorrect
         self.assertEqual(mc['none-test'], None)
-        self.assertIn('none-test', mc)
+        assert 'none-test' in mc

--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -94,3 +94,19 @@ class ClientTests(PylibmcTestCase):
         mc = make_test_client(binary=True)
         ok_(mc.set(k, 0))
         ok_(mc.get(k_enc) == 0)
+
+    def test_get_with_default(self):
+        mc = make_test_client(binary=True)
+        key = 'get-api-test'
+        mc.delete(key)
+        eq_(mc.get(key), None)
+        default = object()
+        assert mc.get(key, default) is default
+
+    def test_none_values(self):
+        mc = make_test_client(binary=True)
+        mc.set('none-test', None)
+        self.assertEqual(mc.get('none-test'), None)
+        self.assertEqual(mc.get('none-test', 'default'), None)
+        # formerly, this would raise a KeyError, which was incorrect
+        self.assertEqual(mc['none-test'], None)

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -47,6 +47,25 @@ class RefcountTests(PylibmcTestCase):
     def test_get_singleton(self):
         self._test_get(b"refcountest3", False)
 
+    def test_get_with_default(self):
+        bc = make_test_client(binary=True)
+        key = b'refcountest4'
+        val = 'some_value'
+        default = object()
+        refcountables = [key, val, default]
+        initial_refcounts = get_refcounts(refcountables)
+        bc.set(key, val)
+        eq_(get_refcounts(refcountables), initial_refcounts)
+        assert bc.get(key) == val
+        eq_(get_refcounts(refcountables), initial_refcounts)
+        assert bc.get(key, default) == val
+        eq_(get_refcounts(refcountables), initial_refcounts)
+        bc.delete(key)
+        assert bc.get(key) is None
+        eq_(get_refcounts(refcountables), initial_refcounts)
+        assert bc.get(key, default) is default
+        eq_(get_refcounts(refcountables), initial_refcounts)
+
     def test_get_multi(self):
         bc = make_test_client(binary=True)
         keys = ["first", "second", "", b""]


### PR DESCRIPTION
The issue I'm trying to address is this: if you store `None` values in memcached with pylibmc, there is no unambiguous way to determine, via either `get` or `__getitem__`, whether a key hit and returned `None` or whether it missed. (It *is* possible to distinguish the cases via `get_multi`, which will return `{'key': None}` in the first case and `{}` in the second.)

Here's the commit message with the details:

````
1. The `get` of _pylibmc.client now matches that of the dict object;
it takes a second argument, which is a default value to return if
the key is not found. If this argument is not passed, it defaults to
None, so this is fully backwards-compatible.

2. This default argument is used to implement `__getitem__` in a way
that unambiguously exposes key misses; previously, `__getitem__` could not
distinguish between a hit that returned a None and a miss. This is a (small)
API break; formerly, this:

client.set('key', None)
client['key']

would raise a KeyError, but now it returns None.
````

This is the same technique that CPython's `Objects/dictobject.c` uses to implement the `get` method of dictionary objects, so I figure it can't be too slow :-) Here's benchmark output that suggests that any difference is lost in the noise (again, with the caveat that I'm reporting stdevs instead of confidence intervals, because I can't get scipy to install in my virtualenvs): https://gist.github.com/slingamn/ddf4665de32859cabff9a10bdef4e17d

Thanks for your time!
