### PR TITLE
Include doc SVG files in source distributions

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -3,6 +3,6 @@ include src/_pylibmcmodule.c src/_pylibmcmodule.h src/pylibmc-version.h
 recursive-include pylibmc *.py
 recursive-include tests *.py
 
-include docs/Makefile docs/make.bat docs/conf.py
+include docs/Makefile docs/make.bat docs/conf.py docs/*.svg
 recursive-include docs *.rst
 recursive-include docs/_themes *


### PR DESCRIPTION
Hi,
The PyPI tarball is missing one SVG file which results in a warning when building the doc:
```
/var/tmp/portage/dev-python/pylibmc-1.5.1/work/pylibmc-1.5.1/docs/behaviors.rst:238: WARNING: image file not readable: failover.svg
```