### PR TITLE
Install documentation: improve pip instructions

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -28,7 +28,6 @@ libmemcached would end up in ``/opt/local``, hence
 From PyPI
 ---------
 
-Since ``pip`` doesn't support passing arguments to the setup script,
-you can also define environment variables::
+Using ``pip`` you can pass install options as follows::
 
-    LIBMEMCACHED=/opt/local pip install pylibmc
+    pip install pylibmc --install-option="--with-libmemcached=/usr/local/"


### PR DESCRIPTION
the installation instructions state you can't use pip to pass parameters
to setup but this is not true. This PR updates the installation
instructions to show how to do that.