### PR TITLE
Include installation instructions with Homebrew for OSX.

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -31,3 +31,8 @@ From PyPI
 Using ``pip`` you can pass install options as follows::
 
     pip install pylibmc --install-option="--with-libmemcached=/usr/local/"
+
+Using Homebrew (MacOSX) you can install from PyPI via::
+
+    brew install libmemcached
+    pip install pylibmc --install-option="--with-libmemcached=/usr/local/Cellar/libmemcached"


### PR DESCRIPTION
This clarifies how to satisfy installing libmemcached using Homebrew on OSX.

Thanks for building this! I hope this helps save someone a StackOverflow search in the future :).