### PR TITLE
Define xrange() in Python 3

### DIFF
--- a/bin/runbench.py
+++ b/bin/runbench.py
@@ -12,6 +12,11 @@ from functools import wraps
 from collections import namedtuple
 from contextlib import contextmanager
 
+try:
+    xrange          # Python 2
+except NameError:
+    xrange = range  # Python 3
+
 
 logger = logging.getLogger('pylibmc.bench')
 


### PR DESCRIPTION
__xrange()__ was removed in Python 3 in favor of __range()__.  Discovered via #237.