### PR TITLE
Undefined name: Declare global _pylibmc in dump_infos()

### DIFF
--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -24,6 +24,7 @@ class PylibmcTestCase(unittest.TestCase):
         del self.mc
 
 def dump_infos():
+    global _pylibmc  # _pylibmc is created when pylibmc is imported
     if hasattr(_pylibmc, "__file__"):
         print("Starting tests with _pylibmc at", _pylibmc.__file__)
     else:


### PR DESCRIPTION
___pylibmc__ is created at https://github.com/lericson/pylibmc/blob/master/src/pylibmc/__init__.py#L71 so declare is as a global here to help linters and humans to understand this undefined name.  Discovered via #237.