### PR TITLE
Officially support Python 3.7

### DIFF
--- a/docs/install.rst
+++ b/docs/install.rst
@@ -5,7 +5,7 @@
 Requirements
 ============
 
-* Python 2.6-2.7, or Python 3.3-3.6
+* Python 2.6-2.7, or Python 3.3-3.7
 * libmemcached 1.0.8 or later (latest tested is 1.0.18)
 * zlib (required for compression support)
 * libsasl2 (required for authentication support)

--- a/setup.py
+++ b/setup.py
@@ -122,5 +122,7 @@ setup(
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{26,27,33,34}
+envlist = py{26,27,33,34,35,36,37}
 
 [testenv]
 commands = {toxinidir}/bin/runtests.py {posargs:-v tests --with-doctest}


### PR DESCRIPTION
I need some form of python memcached support in Python 3.7.

The tests (in tox) are 100% green both for 3.6 and 3.7, ran it against one of ubuntu 18.04s sub-versions of libmemcached11 (v1.0.18-4.2ubuntu0.18.04.1).