### PR TITLE
do not depend on nose

### DIFF
--- a/tests/test_client.py
+++ b/tests/test_client.py
@@ -1,41 +1,34 @@
-import functools
 import sys
 import time
 import pylibmc
 import _pylibmc
 from pylibmc.test import make_test_client
 from tests import PylibmcTestCase
-from nose import SkipTest
-from nose.tools import eq_, ok_
 
 PY3 = sys.version_info[0] >= 3
 
-def requires_memcached_touch(test):
-    @functools.wraps(test)
-    def wrapper(*args, **kwargs):
-        if _pylibmc.libmemcached_version_hex >= 0x01000002:
-            return test(*args, **kwargs)
-        raise SkipTest
-
-    return wrapper
+def requires_memcached_touch(arg):
+    if _pylibmc.libmemcached_version_hex >= 0x01000002:
+        return lambda func: func
+    return unittest.skip("old memcached version")
 
 class ClientTests(PylibmcTestCase):
     def test_zerokey(self):
         bc = make_test_client(binary=True)
         k = "\x00\x01"
         test_str = "test"
-        ok_(bc.set(k, test_str))
+        self.assertTrue(bc.set(k, test_str))
         rk = next(iter(bc.get_multi([k])))
-        eq_(k, rk)
+        self.assertEqual(k, rk)
 
     def test_cas(self):
         c = "cas"
         k = "testkey"
         mc = make_test_client(binary=False, behaviors={c: True})
-        ok_(mc.set(k, 0))
+        self.assertTrue(mc.set(k, 0))
         while True:
             rv, cas = mc.gets(k)
-            ok_(mc.cas(k, rv + 1, cas))
+            self.assertTrue(mc.cas(k, rv + 1, cas))
             if rv == 10:
                 break
 
@@ -61,7 +54,7 @@ class ClientTests(PylibmcTestCase):
                 if not behavior.startswith('_')]
 
         sorted_list = lambda L: list(sorted(L))
-        eq_(sorted_list(expected_behaviors),
+        self.assertEqual(sorted_list(expected_behaviors),
             sorted_list(actual_behaviors))
 
     @requires_memcached_touch
@@ -69,18 +62,18 @@ class ClientTests(PylibmcTestCase):
         touch_test  = "touch-test"
         touch_test2 = "touch-test-2"
         tval = "touch-val"
-        ok_(self.mc.set(touch_test, tval, 1))
-        eq_(tval, self.mc.get(touch_test))
+        self.assertTrue(self.mc.set(touch_test, tval, 1))
+        self.assertEqual(tval, self.mc.get(touch_test))
         time.sleep(2)
-        eq_(None, self.mc.get(touch_test))
+        self.assertEqual(None, self.mc.get(touch_test))
 
         self.mc.set(touch_test, tval, 1)
-        eq_(tval, self.mc.get(touch_test))
-        ok_(self.mc.touch(touch_test, 5))
+        self.assertEqual(tval, self.mc.get(touch_test))
+        self.assertTrue(self.mc.touch(touch_test, 5))
         time.sleep(2)
-        eq_(tval, self.mc.get(touch_test))
+        self.assertEqual(tval, self.mc.get(touch_test))
 
-        ok_(not self.mc.touch(touch_test2, 100))
+        self.assertTrue(not self.mc.touch(touch_test2, 100))
 
     def test_exceptions(self):
         self.assertRaises(TypeError, self.mc.set, 1, "hi")
@@ -92,14 +85,14 @@ class ClientTests(PylibmcTestCase):
         k = "a key with a replacement character \ufffd and something non-BMP \U0001f4a3"
         k_enc = k.encode('utf-8')
         mc = make_test_client(binary=True)
-        ok_(mc.set(k, 0))
-        ok_(mc.get(k_enc) == 0)
+        self.assertTrue(mc.set(k, 0))
+        self.assertTrue(mc.get(k_enc) == 0)
 
     def test_get_with_default(self):
         mc = make_test_client(binary=True)
         key = 'get-api-test'
         mc.delete(key)
-        eq_(mc.get(key), None)
+        self.assertEqual(mc.get(key), None)
         default = object()
         assert mc.get(key, default) is default
 

--- a/tests/test_cmemcached.py
+++ b/tests/test_cmemcached.py
@@ -4,7 +4,6 @@
 # These are ported from cmemcached to ensure compatibility.
 
 import pylibmc
-from nose.tools import eq_
 from tests import PylibmcTestCase
 
 a           = "a"
@@ -20,9 +19,9 @@ hello_world = "hello world"
 class TestCmemcached(PylibmcTestCase):
     def testSetAndGet(self):
         self.mc.set(num12345, 12345)
-        eq_(self.mc.get(num12345), 12345)
+        self.assertEqual(self.mc.get(num12345), 12345)
         self.mc.set(str12345, n12345)
-        eq_(self.mc.get(str12345), n12345)
+        self.assertEqual(self.mc.get(str12345), n12345)
 
     def testDelete(self):
         self.mc.set(str12345, n12345)
@@ -42,7 +41,7 @@ class TestCmemcached(PylibmcTestCase):
         self.mc.set("b", "valueB")
         self.mc.set("c", "valueC")
         result = self.mc.get_multi(["a", "b", "c", "", "hello world"])
-        eq_(result, {'a': 'valueA', 'b': 'valueB', 'c': 'valueC'})
+        self.assertEqual(result, {'a': 'valueA', 'b': 'valueB', 'c': 'valueC'})
 
     def testBigGetMulti(self):
         count = 10 ** 4
@@ -56,7 +55,7 @@ class TestCmemcached(PylibmcTestCase):
             d[key] = value
             self.mc.set(key, value)
         result = self.mc.get_multi(keys)
-        eq_(result, d)
+        self.assertEqual(result, d)
 
     def testFunnyDelete(self):
         s = ""
@@ -66,10 +65,10 @@ class TestCmemcached(PylibmcTestCase):
         self.mc.delete(a)
         self.mc.set(a, I_)
         assert self.mc.append(a, Do)
-        eq_(self.mc.get(a), I_Do)
+        self.assertEqual(self.mc.get(a), I_Do)
 
     def testPrepend(self):
         self.mc.delete(a)
         self.mc.set(a, Do)
         assert self.mc.prepend(a, I_)
-        eq_(self.mc.get(a), I_Do)
+        self.assertEqual(self.mc.get(a), I_Do)

--- a/tests/test_pooling.py
+++ b/tests/test_pooling.py
@@ -4,7 +4,6 @@ except ImportError:
     import Queue as queue
 
 import pylibmc
-from nose.tools import eq_, ok_
 from tests import PylibmcTestCase
 
 class PoolTestCase(PylibmcTestCase):
@@ -15,9 +14,9 @@ class ClientPoolTests(PoolTestCase):
         a_str = "a"
         p = pylibmc.ClientPool(self.mc, 2)
         with p.reserve() as smc:
-            ok_(smc)
-            ok_(smc.set(a_str, 1))
-            eq_(smc[a_str], 1)
+            self.assertTrue(smc)
+            self.assertTrue(smc.set(a_str, 1))
+            self.assertEqual(smc[a_str], 1)
 
     def test_exhaust(self):
         p = pylibmc.ClientPool(self.mc, 2)
@@ -30,6 +29,6 @@ class ThreadMappedPoolTests(PoolTestCase):
         a_str = "a"
         p = pylibmc.ThreadMappedPool(self.mc)
         with p.reserve() as smc:
-            ok_(smc)
-            ok_(smc.set(a_str, 1))
-            eq_(smc[a_str], 1)
+            self.assertTrue(smc)
+            self.assertTrue(smc.set(a_str, 1))
+            self.assertEqual(smc[a_str], 1)

--- a/tests/test_refcounts.py
+++ b/tests/test_refcounts.py
@@ -3,8 +3,6 @@ from __future__ import print_function
 
 import datetime
 
-from nose.tools import eq_, ok_
-
 import pylibmc
 import _pylibmc
 from pylibmc.test import make_test_client
@@ -33,9 +31,9 @@ class RefcountTests(PylibmcTestCase):
         refcountables = [key, val]
         initial_refcounts = get_refcounts(refcountables)
         bc.set(key, val)
-        eq_(get_refcounts(refcountables), initial_refcounts)
-        eq_(bc.get(key), val)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(bc.get(key), val)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
     def test_get_complex_type(self):
         self._test_get("refcountest", datetime.datetime.fromtimestamp(0))
@@ -54,16 +52,16 @@ class RefcountTests(PylibmcTestCase):
         refcountables = [key, val, default]
         initial_refcounts = get_refcounts(refcountables)
         bc.set(key, val)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         assert bc.get(key) == val
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         assert bc.get(key, default) == val
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete(key)
         assert bc.get(key) is None
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         assert bc.get(key, default) is default
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
     def test_get_multi(self):
         bc = make_test_client(binary=True)
@@ -72,9 +70,9 @@ class RefcountTests(PylibmcTestCase):
         refcountables = keys + [value]
         initial_refcounts = get_refcounts(refcountables)
         bc.set(keys[0], value)
-        eq_(get_refcounts(refcountables), initial_refcounts)
-        eq_(bc.get_multi(keys), {keys[0]: value})
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(bc.get_multi(keys), {keys[0]: value})
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
     def test_get_multi_bytes_and_unicode(self):
         bc = make_test_client(binary=True)
@@ -84,9 +82,9 @@ class RefcountTests(PylibmcTestCase):
         refcountables = [keys] + [value]
         initial_refcounts = get_refcounts(refcountables)
         bc.set_multi(kv)
-        eq_(get_refcounts(refcountables), initial_refcounts)
-        eq_(bc.get_multi(keys)[keys[0]], value)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(bc.get_multi(keys)[keys[0]], value)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
     def test_delete(self):
         bc = make_test_client(binary=True)
@@ -96,17 +94,17 @@ class RefcountTests(PylibmcTestCase):
         initial_refcounts = get_refcounts(refcountables)
 
         bc.set(keys[0], values[0])
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.set(keys[1], values[1])
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete(keys[0])
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete(keys[1])
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete(keys[0])
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete(keys[1])
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
     def test_incr(self):
         bc = make_test_client(binary=True)
@@ -115,13 +113,13 @@ class RefcountTests(PylibmcTestCase):
         initial_refcounts = get_refcounts(refcountables)
 
         bc.set(keys[0], 1)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.incr(keys[0])
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.set(keys[1], 5)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.incr(keys[1])
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
     def test_set_and_delete_multi(self):
         bc = make_test_client(binary=True)
@@ -131,17 +129,17 @@ class RefcountTests(PylibmcTestCase):
         initial_refcounts = get_refcounts(refcountables)
 
         bc.set_multi(dict(zip(keys, values)))
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete_multi([keys[0]])
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete_multi([keys[1]])
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.set_multi(dict(zip(keys, values)))
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete_multi(keys)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete_multi(keys)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
     def test_prefixes(self):
         bc = make_test_client(binary=True)
@@ -152,19 +150,19 @@ class RefcountTests(PylibmcTestCase):
         initial_refcounts = get_refcounts(refcountables)
 
         bc.set_multi(dict(zip(keys, values)), key_prefix=prefix)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.get_multi(keys, key_prefix=prefix)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete_multi([keys[0]], key_prefix=prefix)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete_multi([keys[1]], key_prefix=prefix)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.set_multi(dict(zip(keys, values)), key_prefix=prefix)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete_multi(keys, key_prefix=prefix)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         bc.delete_multi(keys, key_prefix=prefix)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
     def test_get_invalid_key(self):
         bc = make_test_client(binary=True)
@@ -176,7 +174,7 @@ class RefcountTests(PylibmcTestCase):
         except TypeError:
             raised = True
         assert raised
-        eq_(get_refcounts([key]), initial_refcount)
+        self.assertEqual(get_refcounts([key]), initial_refcount)
 
     def test_cas(self):
         k = "testkey"
@@ -185,12 +183,12 @@ class RefcountTests(PylibmcTestCase):
         refcountables = [k, val]
         initial_refcounts = get_refcounts(refcountables)
 
-        ok_(mc.set(k, 0))
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertTrue(mc.set(k, 0))
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         while True:
             rv, cas = mc.gets(k)
-            eq_(get_refcounts(refcountables), initial_refcounts)
-            ok_(mc.cas(k, rv + 1, cas))
-            eq_(get_refcounts(refcountables), initial_refcounts)
+            self.assertEqual(get_refcounts(refcountables), initial_refcounts)
+            self.assertTrue(mc.cas(k, rv + 1, cas))
+            self.assertEqual(get_refcounts(refcountables), initial_refcounts)
             if rv == 10:
                 break

--- a/tests/test_serialization.py
+++ b/tests/test_serialization.py
@@ -7,8 +7,6 @@ import datetime
 import json
 import sys
 
-from nose.tools import eq_, ok_
-
 import pylibmc
 import _pylibmc
 from pylibmc.test import make_test_client
@@ -36,16 +34,16 @@ class SerializationMethodTests(PylibmcTestCase):
     def test_integers(self):
         c = make_test_client(binary=True)
         if sys.version_info[0] == 3:
-            eq_(c.serialize(1), (b'1', f_long))
-            eq_(c.serialize(2**64), (b'18446744073709551616', f_long))
+            self.assertEqual(c.serialize(1), (b'1', f_long))
+            self.assertEqual(c.serialize(2**64), (b'18446744073709551616', f_long))
         else:
-            eq_(c.serialize(1), (b'1', f_int))
-            eq_(c.serialize(2**64), (b'18446744073709551616', f_long))
+            self.assertEqual(c.serialize(1), (b'1', f_int))
+            self.assertEqual(c.serialize(2**64), (b'18446744073709551616', f_long))
 
-            eq_(c.deserialize(b'1', f_int), 1)
+            self.assertEqual(c.deserialize(b'1', f_int), 1)
 
-        eq_(c.deserialize(b'18446744073709551616', f_long), 2**64)
-        eq_(c.deserialize(b'1', f_long), long_(1))
+        self.assertEqual(c.deserialize(b'18446744073709551616', f_long), 2**64)
+        self.assertEqual(c.deserialize(b'1', f_long), long_(1))
 
     def test_nonintegers(self):
         # tuples (python_value, (expected_bytestring, expected_flags))
@@ -67,8 +65,8 @@ class SerializationMethodTests(PylibmcTestCase):
 
         c = make_test_client(binary=True)
         for value, serialized_value in SERIALIZATION_TEST_VALUES:
-            eq_(c.serialize(value), serialized_value)
-            eq_(c.deserialize(*serialized_value), value)
+            self.assertEqual(c.serialize(value), serialized_value)
+            self.assertEqual(c.deserialize(*serialized_value), value)
 
 
 class SerializationTests(PylibmcTestCase):
@@ -95,7 +93,7 @@ class SerializationTests(PylibmcTestCase):
                 assert d['a'] == 1
 
         c = make_test_client(MyClient, behaviors={'cas': True})
-        eq_(c.get('notathing'), None)
+        self.assertEqual(c.get('notathing'), None)
 
         refcountables = ['foo', 'myobj', 'noneobj', 'myobj2', 'cachemiss']
         initial_refcounts = get_refcounts(refcountables)
@@ -106,27 +104,27 @@ class SerializationTests(PylibmcTestCase):
         c['myobj2'] = MyObject()
 
         # Show that everything is initially regular.
-        eq_(c.get('myobj'), MyObject())
-        eq_(get_refcounts(refcountables), initial_refcounts)
-        eq_(c.get_multi(['foo', 'myobj', 'noneobj', 'cachemiss']),
+        self.assertEqual(c.get('myobj'), MyObject())
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(c.get_multi(['foo', 'myobj', 'noneobj', 'cachemiss']),
                 dict(foo='foo', myobj=MyObject(), noneobj=None))
-        eq_(get_refcounts(refcountables), initial_refcounts)
-        eq_(c.gets('myobj2')[0], MyObject())
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(c.gets('myobj2')[0], MyObject())
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
         # Show that the subclass can transform unpickling issues into a cache miss.
         del MyObject # Break unpickling
 
-        eq_(c.get('myobj'), None)
-        eq_(get_refcounts(refcountables), initial_refcounts)
-        eq_(c.get_multi(['foo', 'myobj', 'noneobj', 'cachemiss']),
+        self.assertEqual(c.get('myobj'), None)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(c.get_multi(['foo', 'myobj', 'noneobj', 'cachemiss']),
                 dict(foo='foo', noneobj=None))
-        eq_(get_refcounts(refcountables), initial_refcounts)
-        eq_(c.gets('myobj2'), (None, None))
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(c.gets('myobj2'), (None, None))
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
         # The ignored errors are "AttributeError: test.test_client has no MyObject"
-        eq_(len(MyClient.ignored), 3)
+        self.assertEqual(len(MyClient.ignored), 3)
         assert all(isinstance(error, AttributeError) for error in MyClient.ignored)
 
     def test_refcounts(self):
@@ -149,13 +147,13 @@ class SerializationTests(PylibmcTestCase):
         initial_refcounts = get_refcounts(refcountables)
 
         c.set(KEY, VALUE)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         assert c.get(KEY) is SENTINEL
-        eq_(get_refcounts(refcountables), initial_refcounts)
-        eq_(c.get_multi([KEY]), {KEY: SENTINEL})
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(c.get_multi([KEY]), {KEY: SENTINEL})
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
         c.set_multi({KEY: True})
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
     def test_override_serialize(self):
         class MyClient(pylibmc.Client):
@@ -169,7 +167,7 @@ class SerializationTests(PylibmcTestCase):
         c = make_test_client(MyClient)
         c['foo'] = (1, 2, 3, 4)
         # json turns tuples into lists:
-        eq_(c['foo'], [1, 2, 3, 4])
+        self.assertEqual(c['foo'], [1, 2, 3, 4])
 
         raised = False
         try:
@@ -206,7 +204,7 @@ class SerializationTests(PylibmcTestCase):
         c = make_test_client(MyClient)
         initial_refcounts = get_refcounts(refcountables)
         self._assert_set_raises(c, KEY, VALUE)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
     def test_invalid_flags_returned_2(self):
         DUMMY = "ab"
@@ -222,11 +220,11 @@ class SerializationTests(PylibmcTestCase):
         initial_refcounts = get_refcounts(refcountables)
 
         self._assert_set_raises(c, KEY, VALUE)
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)
 
         try:
             c.set_multi({KEY: DUMMY})
         except ValueError:
             raised = True
         assert raised
-        eq_(get_refcounts(refcountables), initial_refcounts)
+        self.assertEqual(get_refcounts(refcountables), initial_refcounts)

--- a/tests/test_translate.py
+++ b/tests/test_translate.py
@@ -1,32 +1,33 @@
-from nose.tools import eq_
 from pylibmc.client import translate_server_spec
 import _pylibmc
+from tests import PylibmcTestCase
 
-def test_translate():
-    eq_(translate_server_spec("111.122.133.144"),
-        (_pylibmc.server_type_tcp, "111.122.133.144", 11211, 1))
-
-def test_translate():
-    eq_(translate_server_spec("111.122.133.144:5555"),
-        (_pylibmc.server_type_tcp, "111.122.133.144", 5555, 1))
-
-def test_udp_translate():
-    eq_(translate_server_spec("udp:199.299.399.499:5555"),
-        (_pylibmc.server_type_udp, "199.299.399.499", 5555, 1))
-
-def test_udp_translate_ipv6():
-    eq_(translate_server_spec("udp:[abcd:abcd::1]:5555"),
-        (_pylibmc.server_type_udp, "abcd:abcd::1", 5555, 1))
-
-def test_translate_with_weight_string():
-    eq_(translate_server_spec("111.122.133.144:5555:2"),
-        (_pylibmc.server_type_tcp, "111.122.133.144", 5555, 2))
-
-def test_translate_with_weight_kwd():
-    eq_(translate_server_spec("111.122.133.144", weight=2),
-        (_pylibmc.server_type_tcp, "111.122.133.144", 11211, 2))
-
-def test_udp_translate_ipv6_with_weight():
-    eq_(translate_server_spec("udp:[abcd:abcd::1]:5555:2"),
-        (_pylibmc.server_type_udp, "abcd:abcd::1", 5555, 2))
+class TranslateTests(PylibmcTestCase):
+    def test_translate(self):
+        self.assertEqual(translate_server_spec("111.122.133.144"),
+                         (_pylibmc.server_type_tcp, "111.122.133.144", 11211, 1))
+    
+    def test_translate(self):
+        self.assertEqual(translate_server_spec("111.122.133.144:5555"),
+                         (_pylibmc.server_type_tcp, "111.122.133.144", 5555, 1))
+    
+    def test_udp_translate(self):
+        self.assertEqual(translate_server_spec("udp:199.299.399.499:5555"),
+                         (_pylibmc.server_type_udp, "199.299.399.499", 5555, 1))
+    
+    def test_udp_translate_ipv6(self):
+        self.assertEqual(translate_server_spec("udp:[abcd:abcd::1]:5555"),
+                         (_pylibmc.server_type_udp, "abcd:abcd::1", 5555, 1))
+    
+    def test_translate_with_weight_string(self):
+        self.assertEqual(translate_server_spec("111.122.133.144:5555:2"),
+                         (_pylibmc.server_type_tcp, "111.122.133.144", 5555, 2))
+    
+    def test_translate_with_weight_kwd(self):
+        self.assertEqual(translate_server_spec("111.122.133.144", weight=2),
+                         (_pylibmc.server_type_tcp, "111.122.133.144", 11211, 2))
+    
+    def test_udp_translate_ipv6_with_weight(self):
+        self.assertEqual(translate_server_spec("udp:[abcd:abcd::1]:5555:2"),
+                         (_pylibmc.server_type_udp, "abcd:abcd::1", 5555, 2))
 


### PR DESCRIPTION
Future python versions will breake nose. Do not depend on it.

Tests still can be run with nosetests.