### PR TITLE
Fix logger.warn() deprecation warnings

### DIFF
--- a/bin/runbench.py
+++ b/bin/runbench.py
@@ -76,18 +76,18 @@ def benchmark_method(f):
 @benchmark_method
 def bench_get_set(mc, key, data):
     if not mc.set(key, data, min_compress_len=4001):
-        logger.warn('set(%r, ...) fail', key)
+        logger.warning('set(%r, ...) fail', key)
     if mc.get(key) != data:
-        logger.warn('get(%r) fail', key)
+        logger.warning('get(%r) fail', key)
 
 
 @benchmark_method
 def bench_get_set_multi(mc, keys, pairs):
     fails = mc.set_multi(pairs)
     if fails:
-        logger.warn('set_multi(%r) fail', fails)
+        logger.warning('set_multi(%r) fail', fails)
     if len(mc.get_multi(keys)) != len(pairs):
-        logger.warn('get_multi() incomplete')
+        logger.warning('get_multi() incomplete')
 
 
 @benchmark_method
@@ -97,7 +97,7 @@ def bench_incr_decr(mc, key):
     mc.incr(key, 2)
     mc.decr(key, 10)
     if mc.get(key) != 0:
-        logger.warn('key not zero')
+        logger.warning('key not zero')
 
 
 def multi_pairs(n, *keys):

--- a/bin/runtests.py
+++ b/bin/runtests.py
@@ -28,10 +28,10 @@ def hack_sys_path():
     if hasattr(_pylibmc, "__file__"):
         logger.info("loaded _pylibmc from %s", _pylibmc.__file__)
         if not _pylibmc.__file__.startswith(lib_dirn):
-            logger.warn("double-check the source path")
-            logger.warn("tests are not running on the dev build!")
+            logger.warning("double-check the source path")
+            logger.warning("tests are not running on the dev build!")
     else:
-        logger.warn("static _pylibmc: %s", _pylibmc)
+        logger.warning("static _pylibmc: %s", _pylibmc)
 
 class PylibmcPlugin(Plugin):
     name = "info"


### PR DESCRIPTION
`logger.warn()` was deprecated in Python 3.3.