### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -101,6 +101,9 @@ setup(
     name="pylibmc",
     version=version,
     url="https://sendapatch.se/projects/pylibmc/",
+    project_urls={
+        "Source": "https://github.com/lericson/pylibmc",
+    },
     author="Ludvig Ericson",
     author_email="ludvig@lericson.se",
     license="3-clause BSD <https://opensource.org/licenses/bsd-license.php>",


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)