### PR TITLE
docs: Fix a few typos

### DIFF
--- a/docs/behaviors.rst
+++ b/docs/behaviors.rst
@@ -220,7 +220,7 @@ Most people desire the classical "I don't really care" type of failover
 support: if a server goes down, just use another one. This case is supported,
 but not by default. As explained above, the default distribution mechanism is
 not very smart, and libmemcached doesn't support any meaningful failover for
-it. If a server goes down, it stays down, and all of its alloted keys will
+it. If a server goes down, it stays down, and all of its allotted keys will
 simply fail. The recommended failover behaviors is for that reason::
 
     mc.behaviors['ketama'] = True

--- a/src/_pylibmcmodule.c
+++ b/src/_pylibmcmodule.c
@@ -292,7 +292,7 @@ static int _PylibMC_Deflate(char *value, Py_ssize_t value_len,
     /* FIXME Failures are entirely silent. */
     int rc;
 
-    /* n.b.: this is called wiile *not* holding the GIL, and must not
+    /* n.b.: this is called while *not* holding the GIL, and must not
        contain Python-API code */
 
     ssize_t out_sz;


### PR DESCRIPTION
There are small typos in:
- docs/behaviors.rst
- src/_pylibmcmodule.c

Fixes:
- Should read `while` rather than `wiile`.
- Should read `allotted` rather than `alloted`.



Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md