### PR TITLE
Fix _unpack_addr when using a unicode spec in Python2

### DIFF
--- a/src/pylibmc-version.h
+++ b/src/pylibmc-version.h
@@ -1,1 +1,1 @@
-#define PYLIBMC_VERSION "1.7.0-dev"
+#define PYLIBMC_VERSION "1.6.1"

--- a/src/pylibmc/client.py
+++ b/src/pylibmc/client.py
@@ -36,7 +36,7 @@ def _unpack_addr(spec, port=None, weight=1):
     else:
         addr = spec
 
-    if isinstance(port, str) and ":" in port:
+    if isinstance(port, (str, unicode)) and ":" in port:
         (port, weight) = port.split(":", 1)
     return (addr, port, weight)
 


### PR DESCRIPTION
Hi! I'm trying to use the library with Python2 and server weights and I'm having issues due to the str instance check [`_unpack_addr`](https://github.com/lericson/pylibmc/blob/1.6.1/src/pylibmc/client.py#L39).

I'm proposing this small change to take into account spec strings which are unicode.