### PR TITLE
build wheels on newer image for py3.12 support

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: 3.12
 
       - name: Set up QEMU
         if: ${{ matrix.os == 'ubuntu-latest' }}


### PR DESCRIPTION
cibuildwheel has dropped support for (launching from, separate to building) 3.7 and we need a newer one to pull in a docker image with py3.12. For now this keeps building 3.7 wheels