### PR TITLE
ci/cd: modernize release pipeline and switch project versioning to setuptools_scm

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -4,84 +4,134 @@ on:
     tags:
     - '*'
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref_name != 'master' }}
+
+permissions: {}
+
 jobs:
-
-  build_wheels:
-    name: Build wheel for ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3 
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: 3.13
-
-      - name: Set up QEMU
-        if: ${{ matrix.os == 'ubuntu-latest' }}
-        uses: docker/setup-qemu-action@v1
-
-      - name: Install cibuildwheel
-        run: |
-          python -m pip install cibuildwheel
-
-      - name: Install prebuilt Universal libraries for macOS
-        if: ${{ matrix.os == 'macos-latest' }}
-        run: |
-          curl --output libs.tgz https://bsg.lericson.se/pylibmc_macos_libs.tar.gz
-          tar -C /usr/local -xzmvf libs.tgz
-          rm libs.tgz
-
-      - name: Build wheels
-        env:
-          CIBW_SKIP: "*-musllinux* pp*"
-          CIBW_ARCHS_MACOS: "x86_64 arm64"
-          CIBW_ARCHS_LINUX: "x86_64 aarch64"
-          CIBW_BEFORE_BUILD_LINUX: "yum install -y libmemcached-devel"
-          # We set DYLD_LIBRARY_PATH because of what appears to be a bug in
-          # `delocate`, the program that bundles up the shared library
-          # dependencies into the wheel file. The linker makes a link like
-          # @rpath/libmemcached.11.dylib or similar, and delocate is unable to
-          # resolve this @rpath macro into /usr/local/lib for some reason. It
-          # would appear that delocate expects an LC_RPATH command to be listed
-          # by `otool -l _pylibmc....so`, which it isn't. This does not seem to
-          # be a problem for the DYLD system itself though, so again, likely a
-          # bug in delocate. Fix by encouraging with DYLD_LIBRARY_PATH.
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: "env DYLD_LIBRARY_PATH=/usr/local/lib delocate-wheel --require-archs {delocate_archs} -w {dest_dir} {wheel}"
-        run: |
-          cibuildwheel --output-dir ./wheelhouse
-
-      - name: Upload artifacts
-        uses: actions/upload-artifact@v3
-        with:
-          name: wheels
-          path: ./wheelhouse/*.whl
-
   build_sdist:
     name: Build source distribution
     runs-on: ubuntu-latest
+    services:
+      memcached:
+        image: memcached:1.6.12
+        ports:
+          - 11211:11211
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/checkout@v6.0.1
         with:
-          python-version: '3.7'
-
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Setup Python
+        uses: actions/setup-python@v6.1.0
+        with:
+          python-version: '3.14'
+      - name: Install build dependencies
+        run: |
+          pip install --upgrade pip build setuptools setuptools_scm
       - name: Build sdist
         run: |
-          python setup.py sdist
-
+          python -m build --sdist
+          ls -l dist
+          python -c "import setuptools_scm; print(setuptools_scm.get_version())"
+      - name: Install test dependencies
+        run: |
+          sudo apt-get update -y -q
+          sudo apt-get install -y -q libmemcached-dev
+          pip install --upgrade -r ./requirements_test.txt
+          pip install dist/*.tar.gz
+      - name: Run tests
+        run: python bin/runtests.py -v tests --with-doctest
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v6.0.0
         with:
           name: dist
           path: dist/*.tar.gz
 
+  generate_wheels_matrix:
+    name: Generate wheels matrix
+    runs-on: ubuntu-latest
+    outputs:
+      include: ${{ steps.set-matrix.outputs.include }}
+    steps:
+      - uses: actions/checkout@v6.0.1
+      - name: Install cibuildwheel
+        run: pipx install cibuildwheel==3.3.1
+      - id: set-matrix
+        run: |
+          MATRIX=$(
+            {
+              cibuildwheel --print-build-identifiers --platform linux \
+              | jq -nRc '{"only": inputs, "os": "ubuntu-22.04"}' \
+              | sed -e '/aarch64/s|ubuntu-22.04|ubuntu-22.04-arm|' \
+              && cibuildwheel --print-build-identifiers --platform macos \
+              | jq -nRc '{"only": inputs, "os": "macos-latest"}'
+            } | jq -sc
+          )
+          echo "include=$MATRIX"
+          echo "include=$MATRIX" >> $GITHUB_OUTPUT
+
+  build_wheels:
+    name: Build for ${{ matrix.only }}
+    needs: [generate_wheels_matrix]
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJson(needs.generate_wheels_matrix.outputs.include) }}
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v6.0.1
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+      - name: Setup QEMU
+        if: runner.os == 'Linux'
+        uses: docker/setup-qemu-action@v3.7.0
+        with:
+          platforms: all
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v3.3.1
+        with:
+          only: ${{ matrix.only }}
+      - name: Upload wheels
+        uses: actions/upload-artifact@v6.0.0
+        with:
+          path: ./wheelhouse/*.whl
+          name: pylibmc-${{ matrix.only }}
+
+  release:
+    name: Create GitHub release
+    needs:
+      - build_wheels
+      - build_sdist
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Download wheel artifacts
+        uses: actions/download-artifact@v7.0.0
+        with:
+          pattern: pylibmc-*
+          merge-multiple: true
+          path: wheels
+      - name: Download sdist artifact
+        uses: actions/download-artifact@v7.0.0
+        with:
+          name: dist
+          path: dist
+      - name: Release on GitHub
+        uses: softprops/action-gh-release@v2.5.0
+        with:
+          draft: true
+          files: |
+            wheels/*.whl
+            dist/*.tar.gz
+
+  # TODO: Copied from the old workflow. It's not tested yet.
   #upload_pypi:
   #  needs: [build_wheels, build_sdist]
   #  runs-on: ubuntu-latest
@@ -101,23 +151,3 @@ jobs:
   #      with:
   #        user: ${{ secrets.PYPI_USERNAME }}
   #        password: ${{ secrets.PYPI_PASSWORD }}
-
-  release:
-    name: Create GitHub release
-    needs:
-      - build_wheels
-      - build_sdist
-    runs-on: ubuntu-latest
-    steps:
-      - name: Download artifacts
-        uses: actions/download-artifact@v3
-      - name: Make zip of artifacts
-        run: |
-          zip -0 artifacts.zip wheels/*.whl dist/*.tar.gz
-      - name: Release on GitHub
-        uses: softprops/action-gh-release@v1
-        with:
-          files: |
-            wheels/*.whl
-            dist/*.tar.gz
-            artifacts.zip

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: CI
 on:
-  - push
-  - pull_request
+  push:
+  pull_request:
 
 jobs:
   test:
@@ -9,23 +9,22 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9", "pypy3.10", "pypy3.11"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.9", "pypy3.10", "pypy3.11"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     name: "${{ matrix.os }} Python: ${{ matrix.python-version }}"
-    env:
-      LIBMEMCACHED_VERSION: '1.0.18'
     services:
       memcached:
         image: memcached:1.6.12
         ports:
           - 11211:11211
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6.0.1
       with:
         fetch-depth: 0
+        fetch-tags: true
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v6.1.0
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ tmp
 MANIFEST
 sendapatch.se
 *.swp
+src/pylibmc/_version.py

--- a/bin/runtests.py
+++ b/bin/runtests.py
@@ -1,4 +1,4 @@
-#!./bin/with-memcached python3
+#!./bin/with-memcached python
 
 if __name__ == "__main__":
     import pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,45 @@
+[build-system]
+requires = ["setuptools>=69", "wheel", "setuptools_scm[toml]>=8"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools_scm]
+write_to = "src/pylibmc/_version.py"
+local_scheme = "no-local-version"
+
+[tool.cibuildwheel]
+build = [
+    "cp39-*",
+    "cp310-*",
+    "cp311-*",
+    "cp312-*",
+    "cp313-*",
+    "cp314-*"
+]
+build-verbosity = 1
+build-frontend = "build"
+before-test = "pip install --upgrade -r requirements_test.txt"
+test-command = "cd {package} && MEMCACHED_ARGS='-u root -p 11211' ./bin/with-memcached python ./bin/runtests.py"
+
+[tool.cibuildwheel.linux]
+archs = ["x86_64", "aarch64"]
+
+[tool.cibuildwheel.macos]
+archs = ["x86_64", "arm64"]
+environment = { LIBMEMCACHED = "/opt/homebrew/opt/libmemcached" }
+
+[[tool.cibuildwheel.overrides]]
+select = "*-manylinux*"
+before-all = "yum makecache && yum install -y libmemcached-devel memcached"
+
+[[tool.cibuildwheel.overrides]]
+select = "*-musllinux*"
+before-all = "apk update && apk add --no-cache libmemcached-dev memcached"
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx*"
+before-all = "brew update && brew install libmemcached memcached"
+
+[[tool.cibuildwheel.overrides]]
+select = "*-macosx_arm64"
+inherit.environment = "append"
+environment = { MACOSX_DEPLOYMENT_TARGET = "15.0" }

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,3 @@
 pytest
 setuptools
+setuptools_scm

--- a/setup.py
+++ b/setup.py
@@ -94,12 +94,11 @@ if cmd == "gen-setup":
 
 with open("README.rst", encoding="utf-8") as r:
     readme_text = r.read()
-with open("src/pylibmc-version.h", encoding="utf-8") as r:
-    version = r.read().strip().split("\"")[1]
 
 setup(
     name="pylibmc",
-    version=version,
+    use_scm_version=True,
+    setup_requires=["setuptools_scm>=8"],
     url="https://sendapatch.se/projects/pylibmc/",
     project_urls={
         "Source": "https://github.com/lericson/pylibmc",

--- a/src/pylibmc/__init__.py
+++ b/src/pylibmc/__init__.py
@@ -70,10 +70,15 @@ See http://sendapatch.se/projects/pylibmc/
 
 import _pylibmc
 from _pylibmc import *
-from _pylibmc import __version__
+from _pylibmc import __version__ as _ext_version
 from .consts import hashers, distributions
 from .client import Client
 from .pools import ClientPool, ThreadMappedPool
+
+try:
+    from ._version import version as __version__
+except ImportError:
+    __version__ = _ext_version
 
 def build_info():
     return ("pylibmc %s for libmemcached %s (compression=%s, sasl=%s)"


### PR DESCRIPTION
- Reworked CD workflow in .github/workflows/cd.yml:
  - Added workflow concurrency controls and default least-privilege permissions.
  - Added a dedicated sdist build job using Python 3.14 with memcached service validation.
  - Added dynamic wheel matrix generation using cibuildwheel build identifiers.
  - Switched wheel builds to pypa/cibuildwheel action and per-target artifact naming.
  - Updated checkout/setup actions and Linux QEMU setup for broader architecture support.
  - Ran tests using generated wheel artificat
  - Reworked release job to download merged wheel/sdist artifacts and publish draft GitHub releases.
  - Removed legacy artifact zip packaging flow and old action versions.

- Updated CI workflow in .github/workflows/ci.yml:
  - Normalized trigger syntax for push and pull_request events.
  - Extended test matrix with Python 3.14.
  - Upgraded checkout/setup-python action versions and enabled tag fetching.
  - Removed obsolete LIBMEMCACHED_VERSION environment usage.

- Introduced pyproject.toml build configuration:
  - Added setuptools build-system metadata with setuptools_scm integration.
  - Configured setuptools_scm to write src/pylibmc/_version.py and disable local version suffixes.
  - Added cibuildwheel global config, per-platform arch settings, and platform-specific dependency install overrides.

- Updated packaging/runtime integration:
  - setup.py now uses SCM-derived versions (use_scm_version + setup_requires).
  - src/pylibmc/__init__.py now prefers generated package version with extension version fallback.
  - Added setuptools_scm to requirements_test.txt.
  - Added src/pylibmc/_version.py to .gitignore.
  - Made bin/runtests.py shebang interpreter-agnostic by using "python" instead of "python3".